### PR TITLE
[FEAT] 카카오 소셜 로그인 구현

### DIFF
--- a/CarryUsServer/build.gradle
+++ b/CarryUsServer/build.gradle
@@ -22,6 +22,7 @@ repositories {
 }
 
 dependencies {
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.2'
 	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.2'

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/auth/controller/AuthController.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/auth/controller/AuthController.java
@@ -1,0 +1,42 @@
+package com.SMWU.CarryUsServer.domain.auth.controller;
+
+import com.SMWU.CarryUsServer.domain.auth.controller.dto.enums.AuthType;
+import com.SMWU.CarryUsServer.domain.auth.controller.dto.request.MemberRequestDTO;
+import com.SMWU.CarryUsServer.domain.auth.controller.dto.response.MemberAuthResponseDTO;
+import com.SMWU.CarryUsServer.domain.auth.exception.AuthSuccessType;
+import com.SMWU.CarryUsServer.domain.auth.service.AuthServiceProvider;
+import com.SMWU.CarryUsServer.domain.auth.service.vo.MemberSignUpVO;
+import com.SMWU.CarryUsServer.domain.member.entity.enums.PlatformType;
+import com.SMWU.CarryUsServer.global.jwt.JwtService;
+import com.SMWU.CarryUsServer.global.response.SuccessResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class AuthController {
+    private final AuthServiceProvider authServiceProvider;
+    private final JwtService jwtService;
+
+    @PostMapping(value = "/auth/social/login", name = "소셜 로그인")
+    public ResponseEntity<SuccessResponse<MemberAuthResponseDTO>> signUp(
+            @RequestHeader(value = "Platform-token", required = false) final String platformToken,
+            @RequestBody @Valid final MemberRequestDTO request) {
+        MemberSignUpVO vo =
+                authServiceProvider
+                        .getAuthService(PlatformType.of(request.platformType()))
+                        .saveMemberOrLogin(platformToken, request);
+        MemberAuthResponseDTO responseDTO = jwtService.issueToken(vo);
+        if (responseDTO.authType().equals(AuthType.SIGN_UP)) {
+            return ResponseEntity.status(HttpStatus.CREATED)
+                    .body(SuccessResponse.of(AuthSuccessType.SIGN_UP_SUCCESS, responseDTO));
+        }
+        return ResponseEntity.ok().body(SuccessResponse.of(AuthSuccessType.LOGIN_SUCCESS, responseDTO));
+    }
+}

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/auth/controller/AuthTestController.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/auth/controller/AuthTestController.java
@@ -1,0 +1,60 @@
+package com.SMWU.CarryUsServer.domain.auth.controller;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@RestController
+@RequestMapping("/test")
+public class AuthTestController {
+
+    @Value("${spring.security.oauth2.client.kakao.client-id}")
+    private String kakaoClientId;
+
+    @Value("${spring.security.oauth2.client.kakao.client-secret}")
+    private String kakaoClientSecret;
+
+    @Value("${spring.security.oauth2.client.kakao.redirect-uri}")
+    private String redirectUri = "http://localhost:8080/test/kakao/callback";
+
+    @GetMapping("/authTest")
+    public String authTest(HttpServletRequest request, HttpServletResponse response) {
+        String kakaoRedirectURL = "https://kauth.kakao.com/oauth/authorize?client_id=" + kakaoClientId
+                + "&redirect_uri=" + redirectUri
+                + "&response_type=code";
+
+        try {
+            response.sendRedirect(kakaoRedirectURL);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        return "SUCCESS";
+    }
+
+    @GetMapping("/kakao/access-token")
+    public ResponseEntity<String> getKakaoAccessToken(@RequestParam("code") String code) {
+            WebClient webClient = WebClient.create("https://kauth.kakao.com");
+
+        String responseBody = webClient.post()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/oauth/token")
+                        .queryParam("grant_type", "authorization_code")
+                        .queryParam("client_id", kakaoClientId)
+                        .queryParam("redirect_uri", redirectUri)
+                        .queryParam("code", code)
+                        .build())
+                .retrieve()
+                .bodyToMono(String.class)
+                .block();
+
+        return ResponseEntity.ok(responseBody);
+    }
+
+}

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/auth/controller/dto/request/MemberRequestDTO.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/auth/controller/dto/request/MemberRequestDTO.java
@@ -1,0 +1,10 @@
+package com.SMWU.CarryUsServer.domain.auth.controller.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record MemberRequestDTO(
+        @NotNull
+        String platformType,
+        @NotNull
+        String role) {
+}

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/auth/controller/dto/response/MemberAuthResponseDTO.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/auth/controller/dto/response/MemberAuthResponseDTO.java
@@ -1,4 +1,4 @@
-package com.SMWU.CarryUsServer.domain.auth.controller.dto;
+package com.SMWU.CarryUsServer.domain.auth.controller.dto.response;
 
 import com.SMWU.CarryUsServer.domain.auth.controller.dto.enums.AuthType;
 import com.SMWU.CarryUsServer.domain.member.entity.enums.Role;

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/auth/controller/dto/response/MemberReissueResponseDTO.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/auth/controller/dto/response/MemberReissueResponseDTO.java
@@ -1,4 +1,4 @@
-package com.SMWU.CarryUsServer.domain.auth.controller.dto;
+package com.SMWU.CarryUsServer.domain.auth.controller.dto.response;
 
 public record MemberReissueResponseDTO(Long memberId, String accessToken, String refreshToken) {
     public static MemberReissueResponseDTO of(Long memberId, String accessToken, String refreshToken) {

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/auth/exception/AuthExceptionType.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/auth/exception/AuthExceptionType.java
@@ -12,6 +12,8 @@ public enum AuthExceptionType implements ExceptionType {
      */
     INVALID_MEMBER_PLATFORM_AUTHORIZATION_CODE(HttpStatus.BAD_REQUEST, "유효하지 않은 플랫폼 인가코드입니다."),
     INVALID_PLATFORM_TYPE(HttpStatus.BAD_REQUEST, "올바르지 않은 플랫폼 유형입니다."),
+
+    INVALID_MEMBER_ROLE(HttpStatus.BAD_REQUEST, "올바르지 않은 사용자 유형입니다."),
     INVALID_ACCESS_TOKEN(HttpStatus.BAD_REQUEST, "서비스에서 발급되지 않은 액세스 토큰입니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "서비스에서 발급되지 않거나 이미 사용된 리프레시 토큰입니다."),
 

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/auth/exception/AuthSuccessType.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/auth/exception/AuthSuccessType.java
@@ -1,0 +1,26 @@
+package com.SMWU.CarryUsServer.domain.auth.exception;
+
+import com.SMWU.CarryUsServer.global.exception.SuccessType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum AuthSuccessType implements SuccessType {
+    SIGN_UP_SUCCESS(HttpStatus.CREATED, "회원가입에 성공하였습니다."),
+    LOGIN_SUCCESS(HttpStatus.OK, "로그인에 성공하였습니다."),
+    REISSUE_SUCCESS(HttpStatus.OK, "리프레시 토큰 재발급에 성공하였습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+
+    @Override
+    public HttpStatus status() {
+        return this.status;
+    }
+
+    @Override
+    public String message() {
+        return this.message;
+    }
+
+}

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/auth/service/AuthService.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/auth/service/AuthService.java
@@ -23,16 +23,16 @@ public abstract class AuthService {
                 .orElse(null);
     }
 
-    protected Member saveUser(final MemberRequestDTO request, final String platformId, final String nickname, final String phoneNumber, final String profileImg) {
-        Member newMember = createSocialMember(platformId, nickname, PlatformType.of(request.platformType()), Role.of(request.role()), phoneNumber, profileImg);
+    protected Member saveUser(final MemberRequestDTO request, final String platformId, final String name, final String phoneNumber, final String profileImg) {
+        Member newMember = createSocialMember(platformId, name, PlatformType.of(request.platformType()), Role.of(request.role()), phoneNumber, profileImg);
         return memberRepository.saveAndFlush(newMember);
     }
 
-    private static Member createSocialMember(final String platformId, final String nickname, final PlatformType platformType, final Role role,
+    private static Member createSocialMember(final String platformId, final String name, final PlatformType platformType, final Role role,
                                              final String phoneNumber, final String profileImg) {
         return Member.builder()
                 .platformId(platformId)
-                .nickname(nickname)
+                .name(name)
                 .platformType(platformType)
                 .role(role)
                 .phoneNumber(phoneNumber)

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/auth/service/AuthService.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/auth/service/AuthService.java
@@ -1,0 +1,42 @@
+package com.SMWU.CarryUsServer.domain.auth.service;
+
+import com.SMWU.CarryUsServer.domain.auth.controller.dto.request.MemberRequestDTO;
+import com.SMWU.CarryUsServer.domain.auth.service.vo.MemberSignUpVO;
+import com.SMWU.CarryUsServer.domain.member.entity.Member;
+import com.SMWU.CarryUsServer.domain.member.entity.enums.PlatformType;
+import com.SMWU.CarryUsServer.domain.member.entity.enums.Role;
+import com.SMWU.CarryUsServer.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public abstract class AuthService {
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public abstract MemberSignUpVO saveMemberOrLogin(final String platformType, final MemberRequestDTO request);
+
+    protected Member getMember(final PlatformType platformType, final String platformId) {
+        return memberRepository.findByPlatformTypeAndPlatformId(platformType, platformId)
+                .orElse(null);
+    }
+
+    protected Member saveUser(final MemberRequestDTO request, final String platformId, final String nickname, final String phoneNumber, final String profileImg) {
+        Member newMember = createSocialMember(platformId, nickname, PlatformType.of(request.platformType()), Role.of(request.role()), phoneNumber, profileImg);
+        return memberRepository.saveAndFlush(newMember);
+    }
+
+    private static Member createSocialMember(final String platformId, final String nickname, final PlatformType platformType, final Role role,
+                                             final String phoneNumber, final String profileImg) {
+        return Member.builder()
+                .platformId(platformId)
+                .nickname(nickname)
+                .platformType(platformType)
+                .role(role)
+                .phoneNumber(phoneNumber)
+                .profileImg(profileImg)
+                .build();
+    }
+}

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/auth/service/AuthService.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/auth/service/AuthService.java
@@ -7,6 +7,7 @@ import com.SMWU.CarryUsServer.domain.member.entity.enums.PlatformType;
 import com.SMWU.CarryUsServer.domain.member.entity.enums.Role;
 import com.SMWU.CarryUsServer.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/auth/service/AuthServiceProvider.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/auth/service/AuthServiceProvider.java
@@ -1,6 +1,7 @@
 package com.SMWU.CarryUsServer.domain.auth.service;
 
 import com.SMWU.CarryUsServer.domain.member.entity.enums.PlatformType;
+import com.SMWU.CarryUsServer.external.oauth.kakao.KakaoAuthService;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/auth/service/AuthServiceProvider.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/auth/service/AuthServiceProvider.java
@@ -1,0 +1,24 @@
+package com.SMWU.CarryUsServer.domain.auth.service;
+
+import com.SMWU.CarryUsServer.domain.member.entity.enums.PlatformType;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Component
+@RequiredArgsConstructor
+public class AuthServiceProvider {
+    private static final ConcurrentHashMap<PlatformType, AuthService> authSerivceMap = new ConcurrentHashMap<PlatformType, AuthService>();
+
+    private final KakaoAuthService kakaoAuthService;
+
+    @PostConstruct
+    void initialAuthServiceMap() {
+        authSerivceMap.put(PlatformType.KAKAO, kakaoAuthService);
+    }
+
+    public AuthService getAuthService(PlatformType platformType) {
+        return authSerivceMap.get(platformType);
+    }
+}

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/auth/service/KakaoAuthService.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/auth/service/KakaoAuthService.java
@@ -1,0 +1,4 @@
+package com.SMWU.CarryUsServer.domain.auth.service;
+
+public class KakaoAuthService implements AuthService{
+}

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/auth/service/KakaoAuthService.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/auth/service/KakaoAuthService.java
@@ -1,4 +1,0 @@
-package com.SMWU.CarryUsServer.domain.auth.service;
-
-public class KakaoAuthService implements AuthService{
-}

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/auth/service/vo/MemberSignUpVO.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/auth/service/vo/MemberSignUpVO.java
@@ -7,14 +7,14 @@ import com.SMWU.CarryUsServer.domain.member.entity.enums.Role;
 import lombok.Builder;
 
 @Builder
-public record MemberSignUpVO(Long memberId, String platformId, String nickname, PlatformType platformType, Role role,
+public record MemberSignUpVO(Long memberId, String platformId, String name, PlatformType platformType, Role role,
                              String phoneNumber, String profileImg, AuthType authType) {
 
     public static MemberSignUpVO of(Member member, PlatformType platformType, Role role, AuthType authtype) {
         return MemberSignUpVO.builder()
                 .memberId(member.getMemberId())
                 .platformId(member.getPlatformId())
-                .nickname(member.getNickname())
+                .name(member.getName())
                 .platformType(platformType)
                 .role(role)
                 .phoneNumber(member.getPhoneNumber())

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/auth/service/vo/MemberSignUpVO.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/auth/service/vo/MemberSignUpVO.java
@@ -7,14 +7,14 @@ import com.SMWU.CarryUsServer.domain.member.entity.enums.Role;
 import lombok.Builder;
 
 @Builder
-public record MemberSignUpVO(Long memberId, String platformId, String nickName, PlatformType platformType, Role role,
-                             String birthYear, String gender, String phoneNumber, String profileImg, AuthType authType) {
+public record MemberSignUpVO(Long memberId, String platformId, String nickname, PlatformType platformType, Role role,
+                             String phoneNumber, String profileImg, AuthType authType) {
 
     public static MemberSignUpVO of(Member member, PlatformType platformType, Role role, AuthType authtype) {
         return MemberSignUpVO.builder()
                 .memberId(member.getMemberId())
                 .platformId(member.getPlatformId())
-                .nickName(member.getNickname())
+                .nickname(member.getNickname())
                 .platformType(platformType)
                 .role(role)
                 .phoneNumber(member.getPhoneNumber())

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/member/entity/Member.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/member/entity/Member.java
@@ -20,7 +20,7 @@ public class Member extends AuditingTimeEntity {
     @Column(nullable = false)
     private String platformId;
 
-    private String nickname;
+    private String name;
 
     @Enumerated(EnumType.STRING)
     private PlatformType platformType;
@@ -33,10 +33,10 @@ public class Member extends AuditingTimeEntity {
     private String profileImg;
 
     @Builder
-    public Member(Long memberId, String platformId, String nickname, PlatformType platformType, Role role, String phoneNumber, String profileImg) {
+    public Member(Long memberId, String platformId, String name, PlatformType platformType, Role role, String phoneNumber, String profileImg) {
         this.memberId = memberId;
         this.platformId = platformId;
-        this.nickname = nickname;
+        this.name = name;
         this.platformType = platformType;
         this.role = role;
         this.phoneNumber = phoneNumber;

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/member/entity/Member.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/member/entity/Member.java
@@ -10,7 +10,13 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "MEMBERS")
+@Table(
+        name = "MEMBERS",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "PLATFORM_ID_PLATFORM_TYPE_UNIQUE",
+                        columnNames = {"platform_id", "platform_type"})
+        })
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class Member extends AuditingTimeEntity {

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/member/entity/Member.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/member/entity/Member.java
@@ -5,6 +5,7 @@ import com.SMWU.CarryUsServer.domain.member.entity.enums.Role;
 import com.SMWU.CarryUsServer.global.entity.AuditingTimeEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -30,4 +31,15 @@ public class Member extends AuditingTimeEntity {
     private String phoneNumber;
 
     private String profileImg;
+
+    @Builder
+    public Member(Long memberId, String platformId, String nickname, PlatformType platformType, Role role, String phoneNumber, String profileImg) {
+        this.memberId = memberId;
+        this.platformId = platformId;
+        this.nickname = nickname;
+        this.platformType = platformType;
+        this.role = role;
+        this.phoneNumber = phoneNumber;
+        this.profileImg = profileImg;
+    }
 }

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/member/entity/enums/PlatformType.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/member/entity/enums/PlatformType.java
@@ -1,5 +1,16 @@
 package com.SMWU.CarryUsServer.domain.member.entity.enums;
 
+import com.SMWU.CarryUsServer.domain.auth.exception.AuthException;
+
+import java.util.Arrays;
+
+import static com.SMWU.CarryUsServer.domain.auth.exception.AuthExceptionType.INVALID_PLATFORM_TYPE;
+
 public enum PlatformType {
-    KAKAO;
+    KAKAO, NAVER;
+
+    public static PlatformType of(String platformType) {
+        return Arrays.stream(PlatformType.values()).filter(type -> type.toString().equals(platformType)).findAny()
+                .orElseThrow(() -> new AuthException(INVALID_PLATFORM_TYPE));
+    }
 }

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/member/entity/enums/Role.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/member/entity/enums/Role.java
@@ -1,5 +1,15 @@
 package com.SMWU.CarryUsServer.domain.member.entity.enums;
 
+import com.SMWU.CarryUsServer.domain.auth.exception.AuthException;
+
+import java.util.Arrays;
+
+import static com.SMWU.CarryUsServer.domain.auth.exception.AuthExceptionType.INVALID_MEMBER_ROLE;
+
 public enum Role {
     TRAVELER, STORE_OWNER;
+    public static Role of(String role) {
+        return Arrays.stream(Role.values()).filter(type -> type.toString().equals(role)).findAny()
+                .orElseThrow(() -> new AuthException(INVALID_MEMBER_ROLE));
+    }
 }

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/member/repository/MemberRepository.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/member/repository/MemberRepository.java
@@ -8,4 +8,5 @@ import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Long, Member> {
     Optional<Member> findByPlatformTypeAndPlatformId(PlatformType platformType, String PlatformId);
+    Member saveAndFlush(Member member);
 }

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/member/repository/MemberRepository.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/member/repository/MemberRepository.java
@@ -6,6 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface MemberRepoistory extends JpaRepository<Long, Member> {
+public interface MemberRepository extends JpaRepository<Long, Member> {
     Optional<Member> findByPlatformTypeAndPlatformId(PlatformType platformType, String PlatformId);
 }

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/member/repository/MemberRepository.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/member/repository/MemberRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface MemberRepository extends JpaRepository<Long, Member> {
-    Optional<Member> findByPlatformTypeAndPlatformId(PlatformType platformType, String PlatformId);
+public interface MemberRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findByPlatformTypeAndPlatformId(PlatformType platformType, String platformId);
     Member saveAndFlush(Member member);
 }

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/entity/Reservation.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/entity/Reservation.java
@@ -21,11 +21,11 @@ public class Reservation extends AuditingTimeEntity {
     private Long reservationId;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @Column(name = "client_id")
+    @JoinColumn(name = "client_id")
     private Member client;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @Column(name = "store_id")
+    @JoinColumn(name = "store_id")
     private Store store;
 
     private String clientReservationPhoneNumber;

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/external/oauth/kakao/KakaoAuthService.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/external/oauth/kakao/KakaoAuthService.java
@@ -1,0 +1,79 @@
+package com.SMWU.CarryUsServer.domain.auth.service;
+
+import com.SMWU.CarryUsServer.domain.auth.controller.dto.request.MemberRequestDTO;
+import com.SMWU.CarryUsServer.domain.auth.service.vo.MemberSignUpVO;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.web.client.RestTemplate;
+
+public class KakaoAuthService extends AuthService{
+    @Value("${spring.security.oauth2.client.provider.kakao.user-info-uri}")
+    private String kakaoUserInfoUri;
+
+    private final KakaoMemberRepository kakaoMemberRepository;
+
+    public KakaoAuthService(
+            MemberRepository memberRepository, KakaoMemberRepository kakaoMemberRepository) {
+        super(memberRepository);
+        this.kakaoMemberRepository = kakaoMemberRepository;
+    }
+
+    @Override
+    public SignedUpMemberVO saveMemberOrLogin(String platformToken, MemberSignUpRequestDTO request)
+            throws JsonProcessingException {
+        RestTemplate restTemplate = new RestTemplate();
+
+        // 카카오 API로 사용자 정보 요청을 보낼 때 액세스 토큰을 Bearer 토큰 스키마로 전달하기 위한 헤더 설정
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "Bearer " + platformToken);
+        // 헤더를 포함한 HttpEntity 생성
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        // HttpEntity를 사용하여 API 요청을 보내고 응답을 받음
+        // ResponseEntity<String> 타입으로 response를 받음
+        try {
+            String response =
+                    restTemplate.exchange(kakaoUserInfoUri, HttpMethod.GET, entity, String.class).getBody();
+
+            ObjectMapper objectMapper = new ObjectMapper();
+
+            // KakaoOAuthUserInfo 로 반환 받은 값으로 바로 회원가입되게 변경
+            KakaoUserVO userInfoVO = objectMapper.readValue(response, KakaoUserVO.class);
+            System.out.println("userInfoVO: " + userInfoVO.toString());
+
+            Member foundMember =
+                    getUser(request.getPlatformType(), userInfoVO.getKakaoAccount().getEmail());
+
+            if (foundMember != null) {
+                return SignedUpMemberVO.of(foundMember, null, AuthType.LOGIN);
+            }
+
+            Member savedMember = saveUser(request, userInfoVO.getKakaoAccount().getEmail());
+
+            if (!userInfoVO.getKakaoAccount().getAge_range_needs_agreement()
+                    || !userInfoVO.getKakaoAccount().getGender_needs_agreement()) {
+                saveKakaoMemberInfo(userInfoVO, savedMember);
+            }
+            return SignedUpMemberVO.of(savedMember, null, AuthType.SIGN_UP);
+
+        } catch (Exception e) {
+            throw new InvalidKakaoTokenException(
+                    ErrorType.INVALID_KAKAO_TOKEN_EXCEPTION,
+                    ErrorType.INVALID_KAKAO_TOKEN_EXCEPTION.getMessage());
+        }
+    }
+
+    private void saveKakaoMemberInfo(KakaoUserVO kakaoUserVo, Member member) {
+        KakaoMember newKakaoMember =
+                KakaoMember.builder()
+                        .member(member)
+                        .gender(kakaoUserVo.getKakaoAccount().getGender())
+                        .age_range(kakaoUserVo.getKakaoAccount().getAge_range())
+                        .build();
+        kakaoMemberRepository.save(newKakaoMember);
+    }
+}

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/external/oauth/kakao/KakaoAuthService.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/external/oauth/kakao/KakaoAuthService.java
@@ -1,79 +1,57 @@
-package com.SMWU.CarryUsServer.domain.auth.service;
+package com.SMWU.CarryUsServer.external.oauth.kakao;
 
+import com.SMWU.CarryUsServer.domain.auth.controller.dto.enums.AuthType;
 import com.SMWU.CarryUsServer.domain.auth.controller.dto.request.MemberRequestDTO;
+import com.SMWU.CarryUsServer.domain.auth.service.AuthService;
 import com.SMWU.CarryUsServer.domain.auth.service.vo.MemberSignUpVO;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.SMWU.CarryUsServer.domain.member.entity.Member;
+import com.SMWU.CarryUsServer.domain.member.entity.enums.PlatformType;
+import com.SMWU.CarryUsServer.domain.member.entity.enums.Role;
+import com.SMWU.CarryUsServer.domain.member.repository.MemberRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.InvalidPropertyException;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
-import org.springframework.web.client.RestTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
 
-public class KakaoAuthService extends AuthService{
-    @Value("${spring.security.oauth2.client.provider.kakao.user-info-uri}")
+@Slf4j
+@Service
+public class KakaoAuthService extends AuthService {
+    @Value("${spring.security.oauth2.client.kakao.user-info-uri}")
     private String kakaoUserInfoUri;
 
-    private final KakaoMemberRepository kakaoMemberRepository;
-
-    public KakaoAuthService(
-            MemberRepository memberRepository, KakaoMemberRepository kakaoMemberRepository) {
+    public KakaoAuthService(MemberRepository memberRepository) {
         super(memberRepository);
-        this.kakaoMemberRepository = kakaoMemberRepository;
     }
 
     @Override
-    public SignedUpMemberVO saveMemberOrLogin(String platformToken, MemberSignUpRequestDTO request)
-            throws JsonProcessingException {
-        RestTemplate restTemplate = new RestTemplate();
+    public MemberSignUpVO saveMemberOrLogin(String platformToken, MemberRequestDTO request) {
+        KakaoMemberVO userInfoVO = getKakaoUserInfo(platformToken);
+        System.out.println("userInfoVO: " + userInfoVO.toString());
 
-        // 카카오 API로 사용자 정보 요청을 보낼 때 액세스 토큰을 Bearer 토큰 스키마로 전달하기 위한 헤더 설정
-        HttpHeaders headers = new HttpHeaders();
-        headers.set("Authorization", "Bearer " + platformToken);
-        // 헤더를 포함한 HttpEntity 생성
-        HttpEntity<String> entity = new HttpEntity<>(headers);
+        Member foundMember =
+                getMember(PlatformType.of(request.platformType()), userInfoVO.id().toString());
 
-        // HttpEntity를 사용하여 API 요청을 보내고 응답을 받음
-        // ResponseEntity<String> 타입으로 response를 받음
-        try {
-            String response =
-                    restTemplate.exchange(kakaoUserInfoUri, HttpMethod.GET, entity, String.class).getBody();
-
-            ObjectMapper objectMapper = new ObjectMapper();
-
-            // KakaoOAuthUserInfo 로 반환 받은 값으로 바로 회원가입되게 변경
-            KakaoUserVO userInfoVO = objectMapper.readValue(response, KakaoUserVO.class);
-            System.out.println("userInfoVO: " + userInfoVO.toString());
-
-            Member foundMember =
-                    getUser(request.getPlatformType(), userInfoVO.getKakaoAccount().getEmail());
-
-            if (foundMember != null) {
-                return SignedUpMemberVO.of(foundMember, null, AuthType.LOGIN);
-            }
-
-            Member savedMember = saveUser(request, userInfoVO.getKakaoAccount().getEmail());
-
-            if (!userInfoVO.getKakaoAccount().getAge_range_needs_agreement()
-                    || !userInfoVO.getKakaoAccount().getGender_needs_agreement()) {
-                saveKakaoMemberInfo(userInfoVO, savedMember);
-            }
-            return SignedUpMemberVO.of(savedMember, null, AuthType.SIGN_UP);
-
-        } catch (Exception e) {
-            throw new InvalidKakaoTokenException(
-                    ErrorType.INVALID_KAKAO_TOKEN_EXCEPTION,
-                    ErrorType.INVALID_KAKAO_TOKEN_EXCEPTION.getMessage());
+        if (foundMember != null) {
+            return MemberSignUpVO.of(foundMember, PlatformType.KAKAO, Role.of(request.role()), AuthType.LOGIN);
         }
+
+        Member savedMember = saveUser(request, userInfoVO.id().toString(), userInfoVO.kakaoAccount().profile().nickname(), null, userInfoVO.kakaoAccount().profile().thumbnailImageUrl());
+        return MemberSignUpVO.of(savedMember, PlatformType.KAKAO, Role.of(request.role()), AuthType.SIGN_UP);
     }
 
-    private void saveKakaoMemberInfo(KakaoUserVO kakaoUserVo, Member member) {
-        KakaoMember newKakaoMember =
-                KakaoMember.builder()
-                        .member(member)
-                        .gender(kakaoUserVo.getKakaoAccount().getGender())
-                        .age_range(kakaoUserVo.getKakaoAccount().getAge_range())
-                        .build();
-        kakaoMemberRepository.save(newKakaoMember);
+    private KakaoMemberVO getKakaoUserInfo(final String accessToken) {
+        WebClient webClient = WebClient.builder().build();
+        try {
+            return webClient.post()
+                    .uri(kakaoUserInfoUri)
+                    .header("Authorization", "Bearer " + accessToken)
+                    .retrieve()
+                    .bodyToMono(KakaoMemberVO.class)
+                    .block();
+        } catch (Exception e) {
+            log.error("getKakaoUserInfo error = {}", e);
+            throw new InvalidPropertyException(KakaoAuthService.class, "getKakaoUserInfo", "카카오 사용자 정보를 가져오는데 실패했습니다.");
+        }
     }
 }

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/external/oauth/kakao/KakaoMemberVO.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/external/oauth/kakao/KakaoMemberVO.java
@@ -1,0 +1,17 @@
+package com.SMWU.CarryUsServer.external.oauth.kakao;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record KakaoMemberVO(
+        Long id,
+        @JsonProperty("kakao_account") KakaoAccount kakaoAccount
+) {
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record KakaoAccount(Profile profile) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Profile(String nickname, @JsonProperty("thumbnail_image_url") String thumbnailImageUrl) {}
+}
+

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/global/exception/ServerException.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/global/exception/ServerException.java
@@ -1,0 +1,13 @@
+package com.SMWU.CarryUsServer.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class ServerException extends RuntimeException{
+    private final ExceptionType exceptionType;
+
+    public ServerException(ExceptionType exceptionType) {
+        super(exceptionType.message());
+        this.exceptionType = exceptionType;
+    }
+}

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/global/exception/SuccessType.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/global/exception/SuccessType.java
@@ -1,0 +1,13 @@
+package com.SMWU.CarryUsServer.global.exception;
+
+import org.springframework.http.HttpStatus;
+
+public interface SuccessType {
+    HttpStatus status();
+
+    String message();
+
+    default int getHttpStatusCode() {
+        return status().value();
+    }
+}

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/global/jwt/JwtService.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/global/jwt/JwtService.java
@@ -5,7 +5,7 @@ import com.SMWU.CarryUsServer.domain.auth.controller.dto.MemberReissueResponseDT
 import com.SMWU.CarryUsServer.domain.auth.exception.AuthException;
 import com.SMWU.CarryUsServer.domain.auth.service.vo.MemberSignUpVO;
 import com.SMWU.CarryUsServer.domain.member.entity.enums.Role;
-import com.SMWU.CarryUsServer.domain.member.repository.MemberRepoistory;
+import com.SMWU.CarryUsServer.domain.member.repository.MemberRepository;
 import com.SMWU.CarryUsServer.external.redis.RedisTokenRepository;
 import com.SMWU.CarryUsServer.external.redis.RedisTokenVO;
 import io.jsonwebtoken.ExpiredJwtException;
@@ -35,7 +35,7 @@ public class JwtService {
     private String refreshHeader;
 
     private final JwtTokenManager jwtTokenManager;
-    private final MemberRepoistory memberRepoistory;
+    private final MemberRepository memberRepository;
     private final RedisTokenRepository redisTokenRepository;
 
     @Transactional

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/global/jwt/JwtService.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/global/jwt/JwtService.java
@@ -1,7 +1,7 @@
 package com.SMWU.CarryUsServer.global.jwt;
 
-import com.SMWU.CarryUsServer.domain.auth.controller.dto.MemberAuthResponseDTO;
-import com.SMWU.CarryUsServer.domain.auth.controller.dto.MemberReissueResponseDTO;
+import com.SMWU.CarryUsServer.domain.auth.controller.dto.response.MemberAuthResponseDTO;
+import com.SMWU.CarryUsServer.domain.auth.controller.dto.response.MemberReissueResponseDTO;
 import com.SMWU.CarryUsServer.domain.auth.exception.AuthException;
 import com.SMWU.CarryUsServer.domain.auth.service.vo.MemberSignUpVO;
 import com.SMWU.CarryUsServer.domain.member.entity.enums.Role;

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/global/response/SuccessResponse.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/global/response/SuccessResponse.java
@@ -1,0 +1,24 @@
+package com.SMWU.CarryUsServer.global.response;
+
+import com.SMWU.CarryUsServer.global.exception.SuccessType;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+public class SuccessResponse<T> {
+    private final int code;
+    private final String message;
+    private T data;
+
+    public static SuccessResponse of(SuccessType successType) {
+        return new SuccessResponse<>(successType.getHttpStatusCode(), successType.message());
+    }
+
+    public static <T> SuccessResponse<T> of(SuccessType successType, T data) {
+        return new SuccessResponse<T>(successType.getHttpStatusCode(), successType.message(), data);
+    }
+}


### PR DESCRIPTION
## 🛄 PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🛄 반영 브랜치
<!-- feat/login -> dev와 같이 반영 브랜치를 표시합니다 -->
- feat/#7 -> dev
- closed #7

## 🛄 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 카카오 소셜 로그인 기능을 추가했습니다

## 🛄 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
<img width="849" alt="스크린샷 2024-02-25 오후 4 29 45" src="https://github.com/CARRY-US/CarryUs-Server/assets/81363864/eb1da7fc-cb1e-440c-889d-1bdcd22d72f0">

## 🛄 MEMO
<!-- 메모를 기록합니다 -->
