### PR TITLE
[FEAT] 마이페이지 내 정보 조회 API 구현

### DIFF
--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/auth/exception/AuthExceptionType.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/auth/exception/AuthExceptionType.java
@@ -20,10 +20,15 @@ public enum AuthExceptionType implements ExceptionType {
     /**
      * 401 Unauthorized
      */
+    UNAUTHORIZED_MEMBER(HttpStatus.UNAUTHORIZED, "인증되지 않은 사용자입니다."),
     UNAUTHORIZED_MEMBER_LOGIN(HttpStatus.UNAUTHORIZED, "로그인에 실패하였습니다."),
     UNAUTHORIZED_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "기한이 만료된 액세스 토큰입니다."),
     UNAUTHORIZED_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "기한이 만료된 리프레시 토큰입니다."),
 
+    /**
+     * 403 Forbidden
+     */
+    FORBIDDEN_MEMBER(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
 
     /**
      * 404 Not Found

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/member/controller/MyController.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/member/controller/MyController.java
@@ -1,0 +1,29 @@
+package com.SMWU.CarryUsServer.domain.member.controller;
+
+import com.SMWU.CarryUsServer.domain.member.controller.response.MemberProfileResponseDTO;
+import com.SMWU.CarryUsServer.domain.member.entity.Member;
+import com.SMWU.CarryUsServer.domain.member.service.MemberService;
+import com.SMWU.CarryUsServer.global.response.SuccessResponse;
+import com.SMWU.CarryUsServer.global.security.AuthMember;
+import com.sun.net.httpserver.Authenticator;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.SMWU.CarryUsServer.domain.member.exception.MemberSuccessType.MEMBER_PROFILE_GET_SUCCESS;
+
+@RestController
+@RequestMapping("/my")
+@RequiredArgsConstructor
+public class MyController {
+    private final MemberService memberService;
+
+    @GetMapping("/profile")
+    public ResponseEntity<SuccessResponse<MemberProfileResponseDTO>> getMemberProfile(@AuthMember final Member member) {
+        final MemberProfileResponseDTO memberProfileResponseDTO = memberService.getMemberProfile(member);
+        return ResponseEntity.ok()
+                .body(SuccessResponse.of(MEMBER_PROFILE_GET_SUCCESS, memberProfileResponseDTO));
+    }
+}

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/member/controller/response/MemberProfileResponseDTO.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/member/controller/response/MemberProfileResponseDTO.java
@@ -1,0 +1,7 @@
+package com.SMWU.CarryUsServer.domain.member.controller.response;
+
+public record MemberProfileResponseDTO(String memberName, String memberProfileImg) {
+    public static MemberProfileResponseDTO of(String memberName, String memberProfileImg) {
+        return new MemberProfileResponseDTO(memberName, memberProfileImg);
+    }
+}

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/member/entity/enums/Role.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/member/entity/enums/Role.java
@@ -1,6 +1,7 @@
 package com.SMWU.CarryUsServer.domain.member.entity.enums;
 
 import com.SMWU.CarryUsServer.domain.auth.exception.AuthException;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 import java.util.Arrays;
@@ -8,6 +9,7 @@ import java.util.Arrays;
 import static com.SMWU.CarryUsServer.domain.auth.exception.AuthExceptionType.INVALID_MEMBER_ROLE;
 
 @RequiredArgsConstructor
+@Getter
 public enum Role {
     TRAVELER("ROLE_TRAVELER"), STORE_OWNER("ROLE_STORE_OWNER");
 

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/member/exception/MemberSuccessType.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/member/exception/MemberSuccessType.java
@@ -1,0 +1,23 @@
+package com.SMWU.CarryUsServer.domain.member.exception;
+
+import com.SMWU.CarryUsServer.global.exception.SuccessType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum MemberSuccessType implements SuccessType {
+    MEMBER_PROFILE_GET_SUCCESS(HttpStatus.OK, "사용자 프로필 조회에 성공하였습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+
+    @Override
+    public HttpStatus status() {
+        return this.status;
+    }
+
+    @Override
+    public String message() {
+        return this.message;
+    }
+}

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/member/service/MemberService.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/member/service/MemberService.java
@@ -1,0 +1,17 @@
+package com.SMWU.CarryUsServer.domain.member.service;
+
+import com.SMWU.CarryUsServer.domain.member.controller.response.MemberProfileResponseDTO;
+import com.SMWU.CarryUsServer.domain.member.entity.Member;
+import com.SMWU.CarryUsServer.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+    private final MemberRepository memberRepository;
+
+    public MemberProfileResponseDTO getMemberProfile(final Member member) {
+        return MemberProfileResponseDTO.of(member.getName(), member.getProfileImg());
+    }
+}

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/global/security/CustomAuthUser.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/global/security/CustomAuthUser.java
@@ -5,9 +5,12 @@ import com.SMWU.CarryUsServer.domain.member.entity.enums.Role;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 
 @Getter
 @RequiredArgsConstructor
@@ -18,7 +21,10 @@ public class CustomAuthUser implements UserDetails {
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return null;
+
+        List<GrantedAuthority> auth = new ArrayList<>();
+        auth.add(new SimpleGrantedAuthority(this.authority.getValue()));
+        return auth;
     }
 
     @Override

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/global/security/SecurityErrorUtils.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/global/security/SecurityErrorUtils.java
@@ -1,0 +1,27 @@
+package com.SMWU.CarryUsServer.global.security;
+
+import com.SMWU.CarryUsServer.global.response.ErrorResponse;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+import java.io.IOException;
+
+import static com.SMWU.CarryUsServer.domain.auth.exception.AuthExceptionType.FORBIDDEN_MEMBER;
+import static com.SMWU.CarryUsServer.global.security.config.SecurityConfig.UTF_8;
+
+public class SecurityErrorUtils {
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    public static HttpServletResponse getErrorResponse(HttpServletResponse response, HttpStatus httpStatus, ErrorResponse errorResponse) throws IOException {
+        response.setStatus(httpStatus.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(UTF_8);
+        String error = objectMapper.writeValueAsString(ErrorResponse.of(FORBIDDEN_MEMBER));
+        response.getWriter().write(error);
+        return response;
+    }
+}

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/global/security/SecurityErrorUtils.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/global/security/SecurityErrorUtils.java
@@ -1,27 +1,23 @@
 package com.SMWU.CarryUsServer.global.security;
 
 import com.SMWU.CarryUsServer.global.response.ErrorResponse;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletResponse;
-import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 
 import java.io.IOException;
 
-import static com.SMWU.CarryUsServer.domain.auth.exception.AuthExceptionType.FORBIDDEN_MEMBER;
 import static com.SMWU.CarryUsServer.global.security.config.SecurityConfig.UTF_8;
 
 public class SecurityErrorUtils {
     private static final ObjectMapper objectMapper = new ObjectMapper();
 
-    public static HttpServletResponse getErrorResponse(HttpServletResponse response, HttpStatus httpStatus, ErrorResponse errorResponse) throws IOException {
+    public static void getErrorResponse(HttpServletResponse response, HttpStatus httpStatus, ErrorResponse errorResponse) throws IOException {
         response.setStatus(httpStatus.value());
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setCharacterEncoding(UTF_8);
-        String error = objectMapper.writeValueAsString(ErrorResponse.of(FORBIDDEN_MEMBER));
+        String error = objectMapper.writeValueAsString(errorResponse);
         response.getWriter().write(error);
-        return response;
     }
 }

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/global/security/config/SecurityConfig.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/global/security/config/SecurityConfig.java
@@ -64,7 +64,7 @@ public class SecurityConfig {
         http.authorizeHttpRequests(auth -> {
                     auth.requestMatchers(AUTH_WHITELIST).permitAll();
                     auth.requestMatchers(AUTH_WHITELIST_WILDCARD).permitAll();
-                    auth.requestMatchers("/main/**", "/search/**", "/stores/**", "/reservation/**", "/my/**", "/reviews/**").hasAuthority("TRAVELER");
+                    auth.requestMatchers("/main/**", "/search/**", "/stores/**", "/reservation/**", "/my/**", "/reviews/**").hasRole("TRAVELER");
                     auth.anyRequest().authenticated();
                 })
               .exceptionHandling(exceptionConfig ->

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/global/security/filter/JwtExceptionFilter.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/global/security/filter/JwtExceptionFilter.java
@@ -2,6 +2,7 @@ package com.SMWU.CarryUsServer.global.security.filter;
 
 import com.SMWU.CarryUsServer.domain.auth.exception.AuthException;
 import com.SMWU.CarryUsServer.global.response.ErrorResponse;
+import com.SMWU.CarryUsServer.global.security.SecurityErrorUtils;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -14,24 +15,22 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.security.Security;
+
+import static com.SMWU.CarryUsServer.global.security.config.SecurityConfig.UTF_8;
 
 @Component
 @RequiredArgsConstructor
 public class JwtExceptionFilter extends OncePerRequestFilter {
 
     private final ObjectMapper objectMapper;
-    public static final String UTF_8 = "UTF-8";
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         try {
             filterChain.doFilter(request, response);
         } catch (AuthException e) {
-            response.setStatus(HttpStatus.UNAUTHORIZED.value());
-            response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-            response.setCharacterEncoding(UTF_8);
-            String error = objectMapper.writeValueAsString(ErrorResponse.of(e.getExceptionType()));
-            response.getWriter().write(error);
+            SecurityErrorUtils.getErrorResponse(response, HttpStatus.UNAUTHORIZED, ErrorResponse.of(e.getExceptionType()));
         }
     }
 }

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/global/security/handler/CustomAccessDeniedHandler.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/global/security/handler/CustomAccessDeniedHandler.java
@@ -1,0 +1,27 @@
+package com.SMWU.CarryUsServer.global.security.handler;
+
+import com.SMWU.CarryUsServer.domain.auth.exception.AuthExceptionType;
+import com.SMWU.CarryUsServer.global.response.ErrorResponse;
+import com.SMWU.CarryUsServer.global.security.SecurityErrorUtils;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+import static com.SMWU.CarryUsServer.domain.auth.exception.AuthExceptionType.FORBIDDEN_MEMBER;
+
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response,
+                       AccessDeniedException accessDeniedException) throws IOException {
+        SecurityErrorUtils.getErrorResponse(response, HttpStatus.FORBIDDEN, ErrorResponse.of(FORBIDDEN_MEMBER));
+    }
+}

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/global/security/handler/CustomAuthenticationEntryPoint.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/global/security/handler/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,22 @@
+package com.SMWU.CarryUsServer.global.security.handler;
+
+import com.SMWU.CarryUsServer.global.response.ErrorResponse;
+import com.SMWU.CarryUsServer.global.security.SecurityErrorUtils;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+
+import java.io.IOException;
+
+import static com.SMWU.CarryUsServer.domain.auth.exception.AuthExceptionType.*;
+
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException)
+            throws IOException{
+        SecurityErrorUtils.getErrorResponse(response, HttpStatus.UNAUTHORIZED, ErrorResponse.of(UNAUTHORIZED_MEMBER));
+    }
+}


### PR DESCRIPTION
## 🛄 PR 타입
- [x] 기능 추가
- [x] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🛄 반영 브랜치
<!-- feat/login -> dev와 같이 반영 브랜치를 표시합니다 -->
- feat/#11 -> dev
- closed #11

## 🛄 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 마이페이지 내 정보 조회 API를 개발했습니다
- 시큐리티 설정에서 사용자의 권한을 가져오는 코드를 구현하여 권한 확인이 되지 않는 에러를 해결했습니다
- @stellar-halo 언니 의견대로 필터단에서 에러를 처리하는 로직들을 SecurityUtils 클래스를 만들어 함수로 분리했습니다 THX~

## 🛄 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
<img width="855" alt="스크린샷 2024-03-01 오후 6 44 55" src="https://github.com/CARRY-US/CarryUs-Server/assets/81363864/e092fa70-baaf-4fbd-ae52-f11723823ef9">


## 🛄 MEMO
<!-- 메모를 기록합니다 -->
