### PR TITLE
[FEAT] 유저가 리뷰를 남긴 가게 정보 조회

### DIFF
--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/controller/ReviewController.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/controller/ReviewController.java
@@ -1,6 +1,7 @@
 package com.SMWU.CarryUsServer.domain.reservation.controller;
 
 import com.SMWU.CarryUsServer.domain.member.entity.Member;
+import com.SMWU.CarryUsServer.domain.reservation.controller.response.ReservationStoreInfoResponseDTO;
 import com.SMWU.CarryUsServer.domain.reservation.controller.response.ReviewResponseDTO;
 import com.SMWU.CarryUsServer.domain.reservation.service.ReservationReviewService;
 import com.SMWU.CarryUsServer.global.response.SuccessResponse;
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import static com.SMWU.CarryUsServer.domain.reservation.exception.ReviewSuccessType.REVIEW_GET_SUCCESS;
+import static com.SMWU.CarryUsServer.domain.reservation.exception.ReviewSuccessType.REVIEW_STORE_INFO_GET_SUCCESS;
 
 @RequestMapping("/reviews")
 @RestController
@@ -24,5 +26,11 @@ public class ReviewController {
     public ResponseEntity<SuccessResponse<ReviewResponseDTO>> getReviewDetail(@PathVariable("reviewId") final Long reviewId, @AuthMember final Member member) {
         final ReviewResponseDTO responseDTO = reservationReviewService.getReviewDetail(reviewId, member);
         return ResponseEntity.ok(SuccessResponse.of(REVIEW_GET_SUCCESS, responseDTO));
+    }
+
+    @GetMapping("/{reviewId}/store/info")
+    public ResponseEntity<SuccessResponse<ReservationStoreInfoResponseDTO>> getReservationStoreInfo(@PathVariable("reviewId") final Long reviewId, @AuthMember final Member member) {
+        final ReservationStoreInfoResponseDTO responseDTO = reservationReviewService.getReservationStoreInfo(reviewId, member);
+        return ResponseEntity.ok(SuccessResponse.of(REVIEW_STORE_INFO_GET_SUCCESS, responseDTO));
     }
 }

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/controller/response/ReservationStoreInfoResponseDTO.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/controller/response/ReservationStoreInfoResponseDTO.java
@@ -1,0 +1,7 @@
+package com.SMWU.CarryUsServer.domain.reservation.controller.response;
+
+public record ReservationStoreInfoResponseDTO(long storeId, String storeName, String storeLocation, String reservationInfo) {
+    public static ReservationStoreInfoResponseDTO of(long storeId, String storeName, String storeLocation, String reservationInfo) {
+        return new ReservationStoreInfoResponseDTO(storeId, storeName, storeLocation, reservationInfo);
+    }
+}

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/entity/Reservation.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/entity/Reservation.java
@@ -10,6 +10,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 @Entity
 @Table(name = "RESERVATIONS")
@@ -40,4 +41,9 @@ public class Reservation extends AuditingTimeEntity {
     private LocalDateTime reservationStartTime;
 
     private LocalDateTime reservationEndTime;
+
+    public String getReservationInfo(){
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd HH:mm 예약");
+        return reservationStartTime.format(formatter);
+    }
 }

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/exception/ReviewSuccessType.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/exception/ReviewSuccessType.java
@@ -6,7 +6,8 @@ import org.springframework.http.HttpStatus;
 
 @RequiredArgsConstructor
 public enum ReviewSuccessType implements SuccessType {
-    REVIEW_GET_SUCCESS(HttpStatus.OK, "리뷰 상세 조회에 성공하였습니다.");
+    REVIEW_GET_SUCCESS(HttpStatus.OK, "리뷰 상세 조회에 성공하였습니다."),
+    REVIEW_STORE_INFO_GET_SUCCESS(HttpStatus.OK, "리뷰를 남긴 가게에 대한 정보 조회에 성공하였습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/repository/ReservationReviewRepository.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/repository/ReservationReviewRepository.java
@@ -14,4 +14,7 @@ public interface ReservationReviewRepository extends JpaRepository<ReservationRe
     List<ReservationReview> findAllByClient(@Param("client") Member client);
 
     Optional<ReservationReview> findByReservationReviewIdAndReservationClient(Long reservationId, Member client);
+
+    @Query("SELECT rr FROM ReservationReview rr JOIN FETCH rr.reservation r JOIN FETCH r.store WHERE rr.reservationReviewId = :reviewId AND rr.reservation.client = :client")
+    Optional<ReservationReview> findReservationReviewWithReservationStore(@Param("reviewId") Long reviewId, @Param("client") Member client);
 }

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/service/ReservationReviewService.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/service/ReservationReviewService.java
@@ -2,7 +2,9 @@ package com.SMWU.CarryUsServer.domain.reservation.service;
 
 import com.SMWU.CarryUsServer.domain.member.controller.response.MemberReviewResponseDTO;
 import com.SMWU.CarryUsServer.domain.member.entity.Member;
+import com.SMWU.CarryUsServer.domain.reservation.controller.response.ReservationStoreInfoResponseDTO;
 import com.SMWU.CarryUsServer.domain.reservation.controller.response.ReviewResponseDTO;
+import com.SMWU.CarryUsServer.domain.reservation.entity.Reservation;
 import com.SMWU.CarryUsServer.domain.reservation.entity.ReservationReview;
 import com.SMWU.CarryUsServer.domain.reservation.exception.ReviewException;
 import com.SMWU.CarryUsServer.domain.reservation.repository.ReservationReviewRepository;
@@ -41,4 +43,10 @@ public class ReservationReviewService {
                 reservationReview.getReviewContent());
     }
 
+    public ReservationStoreInfoResponseDTO getReservationStoreInfo(final Long reviewId, final Member member){
+        final ReservationReview reservationReview = reservationReviewRepository.findReservationReviewWithReservationStore(reviewId, member)
+                .orElseThrow(() -> new ReviewException(NOT_FOUND_REVIEW));
+        final Reservation reservation = reservationReview.getReservation();
+        return ReservationStoreInfoResponseDTO.of(reservation.getStore().getStoreId(), reservation.getStore().getStoreName(), reservation.getStore().getStoreLocation(), reservation.getReservationInfo());
+    }
 }

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/store/entity/Store.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/store/entity/Store.java
@@ -35,4 +35,8 @@ public class Store {
     private double latitude;
 
     private double longitude;
+
+    public String getStoreLocation(){
+        return state + " " + city + " " + town + " " + addressRest;
+    }
 }


### PR DESCRIPTION
## 🛄 PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🛄 반영 브랜치
<!-- feat/login -> dev와 같이 반영 브랜치를 표시합니다 -->
- feat/#17 -> dev
- closed #17

## 🛄 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 유저가 리뷰를 남긴 가게의 정보를 조회하는 기능을 개발했습니다

## 🛄 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
<img width="857" alt="image" src="https://github.com/CARRY-US/CarryUs-Server/assets/81363864/c0605f1a-ec9c-41f3-8211-65eb2dc131e1">


## 🛄 MEMO
<!-- 메모를 기록합니다 -->
