### PR TITLE
[FEAT] 사용자 현재 위치 기준 가게 리스트 조회

### DIFF
--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/controller/ReservationController.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/controller/ReservationController.java
@@ -1,0 +1,26 @@
+package com.SMWU.CarryUsServer.domain.reservation.controller;
+
+import com.SMWU.CarryUsServer.domain.member.entity.Member;
+import com.SMWU.CarryUsServer.domain.reservation.controller.request.ReviewCreateRequestDTO;
+import com.SMWU.CarryUsServer.domain.reservation.controller.response.ReviewIdResponseDTO;
+import com.SMWU.CarryUsServer.domain.reservation.service.ReservationReviewService;
+import com.SMWU.CarryUsServer.global.response.SuccessResponse;
+import com.SMWU.CarryUsServer.global.security.AuthMember;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import static com.SMWU.CarryUsServer.domain.reservation.exception.ReviewSuccessType.REVIEW_CREATE_SUCCESS;
+
+@RestController
+@RequestMapping("/reservations")
+@RequiredArgsConstructor
+public class ReservationController {
+    private final ReservationReviewService reservationReviewService;
+
+    @PostMapping("/{reservationId}/review")
+    public ResponseEntity<SuccessResponse<ReviewIdResponseDTO>> createReview(@PathVariable("reservationId") final Long reservationId, @RequestBody final ReviewCreateRequestDTO requestDTO, @AuthMember final Member member) {
+        final ReviewIdResponseDTO responseDTO = reservationReviewService.createReview(reservationId, requestDTO, member);
+        return ResponseEntity.ok(SuccessResponse.of(REVIEW_CREATE_SUCCESS, responseDTO));
+    }
+}

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/controller/request/ReviewCreateRequestDTO.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/controller/request/ReviewCreateRequestDTO.java
@@ -1,0 +1,4 @@
+package com.SMWU.CarryUsServer.domain.reservation.controller.request;
+
+public record ReviewCreateRequestDTO(String reviewContent, Double reviewRating) {
+}

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/entity/ReservationReview.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/entity/ReservationReview.java
@@ -4,6 +4,7 @@ import com.SMWU.CarryUsServer.domain.reservation.exception.ReviewException;
 import com.SMWU.CarryUsServer.global.entity.AuditingTimeEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -26,6 +27,14 @@ public class ReservationReview extends AuditingTimeEntity {
 
     private String reviewContent;
 
+    @Builder
+    public ReservationReview (final Reservation reservation, final double reviewRating, final String reviewContent) {
+        validateReviewRating(reviewRating);
+        this.reservation = reservation;
+        this.reviewRating = reviewRating;
+        this.reviewContent = reviewContent;
+    }
+
     public void updateReview(final Double reviewRating, final String reviewContent) {
         if(reviewContent != null && !reviewContent.isBlank()){
             this.reviewContent = reviewContent;
@@ -36,7 +45,7 @@ public class ReservationReview extends AuditingTimeEntity {
         }
     }
 
-    private void validateReviewRating(final double reviewRating) {
+    private static void validateReviewRating(final double reviewRating) {
         if(reviewRating < 0 || reviewRating > 5) {
             throw new ReviewException(ILLEGAL_REVIEW_RATING);
         }

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/entity/ReservationReview.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/entity/ReservationReview.java
@@ -45,7 +45,7 @@ public class ReservationReview extends AuditingTimeEntity {
         }
     }
 
-    private static void validateReviewRating(final double reviewRating) {
+    private void validateReviewRating(final double reviewRating) {
         if(reviewRating < 0 || reviewRating > 5) {
             throw new ReviewException(ILLEGAL_REVIEW_RATING);
         }

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/exception/ReservationException.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/exception/ReservationException.java
@@ -1,0 +1,10 @@
+package com.SMWU.CarryUsServer.domain.reservation.exception;
+
+import com.SMWU.CarryUsServer.global.exception.ClientException;
+import com.SMWU.CarryUsServer.global.exception.ExceptionType;
+
+public class ReservationException extends ClientException {
+    public ReservationException(ExceptionType exceptionType) {
+        super(exceptionType);
+    }
+}

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/exception/ReservationExceptionType.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/exception/ReservationExceptionType.java
@@ -1,0 +1,24 @@
+package com.SMWU.CarryUsServer.domain.reservation.exception;
+
+import com.SMWU.CarryUsServer.global.exception.ExceptionType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum ReservationExceptionType implements ExceptionType {
+    NOT_COMPLETED_RESERVATION(HttpStatus.BAD_REQUEST, "예약이 완료되지 않았습니다."),
+    NOT_FOUND_RESERVATION(HttpStatus.NOT_FOUND, "예약을 찾을 수 없습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+
+    @Override
+    public HttpStatus status() {
+        return this.status;
+    }
+
+    @Override
+    public String message() {
+        return this.message;
+    }
+}

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/exception/ReviewSuccessType.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/exception/ReviewSuccessType.java
@@ -8,7 +8,8 @@ import org.springframework.http.HttpStatus;
 public enum ReviewSuccessType implements SuccessType {
     REVIEW_GET_SUCCESS(HttpStatus.OK, "리뷰 상세 조회에 성공하였습니다."),
     REVIEW_STORE_INFO_GET_SUCCESS(HttpStatus.OK, "리뷰를 남긴 가게에 대한 정보 조회에 성공하였습니다."),
-    REVIEW_UPDATE_SUCCESS(HttpStatus.OK, "리뷰 수정에 성공하였습니다.");
+    REVIEW_UPDATE_SUCCESS(HttpStatus.OK, "리뷰 수정에 성공하였습니다."),
+    REVIEW_CREATE_SUCCESS(HttpStatus.CREATED, "리뷰 작성에 성공하였습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/repository/ReservationRepository.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/repository/ReservationRepository.java
@@ -1,0 +1,11 @@
+package com.SMWU.CarryUsServer.domain.reservation.repository;
+
+import com.SMWU.CarryUsServer.domain.member.entity.Member;
+import com.SMWU.CarryUsServer.domain.reservation.entity.Reservation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ReservationRepository extends JpaRepository<Reservation, Long> {
+    Optional<Reservation> findByReservationIdAndClient(Long id, Member client);
+}

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/repository/ReservationReviewRepository.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/repository/ReservationReviewRepository.java
@@ -17,4 +17,10 @@ public interface ReservationReviewRepository extends JpaRepository<ReservationRe
 
     @Query("SELECT rr FROM ReservationReview rr JOIN FETCH rr.reservation r JOIN FETCH r.store WHERE rr.reservationReviewId = :reviewId AND rr.reservation.client = :client")
     Optional<ReservationReview> findReservationReviewWithReservationStore(@Param("reviewId") Long reviewId, @Param("client") Member client);
+
+    @Query("SELECT AVG(rr.reviewRating) FROM ReservationReview rr JOIN rr.reservation r WHERE r.store.storeId = :storeId")
+    Optional<Double> getStoreRating(@Param("storeId") Long storeId);
+
+    @Query("SELECT COUNT(rr) FROM ReservationReview rr JOIN rr.reservation r WHERE r.store.storeId = :storeId")
+    int getReviewCount(@Param("storeId") Long storeId);
 }

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/service/ReservationReviewService.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/service/ReservationReviewService.java
@@ -2,13 +2,17 @@ package com.SMWU.CarryUsServer.domain.reservation.service;
 
 import com.SMWU.CarryUsServer.domain.member.controller.response.MemberReviewResponseDTO;
 import com.SMWU.CarryUsServer.domain.member.entity.Member;
+import com.SMWU.CarryUsServer.domain.reservation.controller.request.ReviewCreateRequestDTO;
 import com.SMWU.CarryUsServer.domain.reservation.controller.request.ReviewUpdateRequestDTO;
 import com.SMWU.CarryUsServer.domain.reservation.controller.response.ReservationStoreInfoResponseDTO;
 import com.SMWU.CarryUsServer.domain.reservation.controller.response.ReviewIdResponseDTO;
 import com.SMWU.CarryUsServer.domain.reservation.controller.response.ReviewResponseDTO;
 import com.SMWU.CarryUsServer.domain.reservation.entity.Reservation;
 import com.SMWU.CarryUsServer.domain.reservation.entity.ReservationReview;
+import com.SMWU.CarryUsServer.domain.reservation.entity.enums.ReservationType;
+import com.SMWU.CarryUsServer.domain.reservation.exception.ReservationException;
 import com.SMWU.CarryUsServer.domain.reservation.exception.ReviewException;
+import com.SMWU.CarryUsServer.domain.reservation.repository.ReservationRepository;
 import com.SMWU.CarryUsServer.domain.reservation.repository.ReservationReviewRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -17,6 +21,8 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.SMWU.CarryUsServer.domain.reservation.exception.ReservationExceptionType.NOT_COMPLETED_RESERVATION;
+import static com.SMWU.CarryUsServer.domain.reservation.exception.ReservationExceptionType.NOT_FOUND_RESERVATION;
 import static com.SMWU.CarryUsServer.domain.reservation.exception.ReviewExceptiontype.NOT_FOUND_REVIEW;
 
 @Service
@@ -24,6 +30,7 @@ import static com.SMWU.CarryUsServer.domain.reservation.exception.ReviewExceptio
 @Transactional(readOnly = true)
 public class ReservationReviewService {
     private final ReservationReviewRepository reservationReviewRepository;
+    private final ReservationRepository reservationRepository;
 
     public List<MemberReviewResponseDTO> getMemberReviewList(final Member member) {
         final List<ReservationReview> reservationReviews = reservationReviewRepository.findAllByClient(member);
@@ -52,6 +59,26 @@ public class ReservationReviewService {
                 .orElseThrow(() -> new ReviewException(NOT_FOUND_REVIEW));
         final Reservation reservation = reservationReview.getReservation();
         return ReservationStoreInfoResponseDTO.of(reservation.getStore().getStoreId(), reservation.getStore().getStoreName(), reservation.getStore().getStoreLocation(), reservation.getReservationInfo());
+    }
+
+    @Transactional
+    public ReviewIdResponseDTO createReview(final Long reservationId, final ReviewCreateRequestDTO requestDTO, final Member member) {
+        final Reservation reservation = reservationRepository.findByReservationIdAndClient(reservationId, member)
+                .orElseThrow(() -> new ReservationException(NOT_FOUND_RESERVATION));
+        if(reservation.getReservationType().equals(ReservationType.COMPLETED)) {
+            final ReservationReview reservationReview = createReservationReview(reservation, requestDTO);
+            reservationReviewRepository.save(reservationReview);
+            return ReviewIdResponseDTO.of(reservationReview.getReservationReviewId());
+        }
+        throw new ReservationException(NOT_COMPLETED_RESERVATION);
+    }
+
+    private ReservationReview createReservationReview(final Reservation reservation, final ReviewCreateRequestDTO requestDTO) {
+        return ReservationReview.builder()
+                .reservation(reservation)
+                .reviewContent(requestDTO.reviewContent())
+                .reviewRating(requestDTO.reviewRating())
+                .build();
     }
 
     @Transactional

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/store/controller/MainController.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/store/controller/MainController.java
@@ -1,0 +1,33 @@
+package com.SMWU.CarryUsServer.domain.store.controller;
+
+import com.SMWU.CarryUsServer.domain.store.controller.response.StoreResponseDTO;
+import com.SMWU.CarryUsServer.domain.store.service.StoreService;
+import com.SMWU.CarryUsServer.global.response.SuccessResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+import static com.SMWU.CarryUsServer.domain.store.exception.StoreSuccessType.GET_STORE_LIST_BY_MEMBER_LOCATION;
+
+@RestController
+@RequestMapping("/main")
+@RequiredArgsConstructor
+public class MainController {
+    private final StoreService storeService;
+
+    @GetMapping("/location/stores")
+    public ResponseEntity<SuccessResponse<List<StoreResponseDTO>>> getStoreListByMemberLocation(
+            @RequestParam final double xMin,
+            @RequestParam final double xMax,
+            @RequestParam final double yMin,
+            @RequestParam final double yMax){
+        final List<StoreResponseDTO> responseDTO = storeService.getStoreListByMemberLocation(xMin, xMax, yMin, yMax);
+        return ResponseEntity.ok(SuccessResponse.of(GET_STORE_LIST_BY_MEMBER_LOCATION, responseDTO));
+    }
+
+}

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/store/controller/response/StoreResponseDTO.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/store/controller/response/StoreResponseDTO.java
@@ -1,0 +1,15 @@
+package com.SMWU.CarryUsServer.domain.store.controller.response;
+
+public record StoreResponseDTO(
+        long storeId,
+        String storeImgUrl,
+        String storeName,
+        String storeLocation,
+        int storeReviewCount,
+        double storeRatingAverage,
+        double latitude,
+        double longitude) {
+    public static StoreResponseDTO of(long storeId, String storeImgUrl, String storeName, String storeLocation, int storeReviewCount, double storeRatingAverage, double latitude, double longitude){
+        return new StoreResponseDTO(storeId, storeImgUrl, storeName, storeLocation, storeReviewCount, storeRatingAverage, latitude, longitude);
+    }
+}

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/store/exception/StoreSuccessType.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/store/exception/StoreSuccessType.java
@@ -1,0 +1,23 @@
+package com.SMWU.CarryUsServer.domain.store.exception;
+
+import com.SMWU.CarryUsServer.global.exception.SuccessType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum StoreSuccessType implements SuccessType {
+    GET_STORE_LIST_BY_MEMBER_LOCATION(HttpStatus.OK, "사용자 위치 기반 가게 목록 조회에 성공하였습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+
+    @Override
+    public HttpStatus status() {
+        return this.status;
+    }
+
+    @Override
+    public String message() {
+        return this.message;
+    }
+}

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/store/repository/StoreRepository.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/store/repository/StoreRepository.java
@@ -1,0 +1,10 @@
+package com.SMWU.CarryUsServer.domain.store.repository;
+
+import com.SMWU.CarryUsServer.domain.store.entity.Store;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface StoreRepository extends JpaRepository<Store, Long>{
+    List<Store> findByLatitudeBetweenAndLongitudeBetweenOrderByStoreId(double xMin, double xMax, double yMin, double yMax);
+}

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/store/service/StoreService.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/store/service/StoreService.java
@@ -1,0 +1,36 @@
+package com.SMWU.CarryUsServer.domain.store.service;
+
+import com.SMWU.CarryUsServer.domain.reservation.repository.ReservationReviewRepository;
+import com.SMWU.CarryUsServer.domain.store.controller.response.StoreResponseDTO;
+import com.SMWU.CarryUsServer.domain.store.entity.Store;
+import com.SMWU.CarryUsServer.domain.store.repository.StoreRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class StoreService {
+    private final StoreRepository storeRepository;
+    private final ReservationReviewRepository reviewRepository;
+    public static final double EMPTY_RATING = 0.0;
+
+    public List<StoreResponseDTO> getStoreListByMemberLocation(final double xMin, final double xMax, final double yMin, final double yMax) {
+        final List<Store> storeList = storeRepository.findByLatitudeBetweenAndLongitudeBetweenOrderByStoreId(xMin, xMax, yMin, yMax);
+        List<StoreResponseDTO> responseDTOList = new ArrayList<>();
+        for(Store store : storeList) {
+            final int reviewCount = reviewRepository.getReviewCount(store.getStoreId());
+        final double reviewRating = reviewRepository.getStoreRating(store.getStoreId()).orElse(EMPTY_RATING);
+            responseDTOList.add(toResponseDTO(store, reviewCount, reviewRating));
+        }
+        return responseDTOList;
+    }
+
+    private StoreResponseDTO toResponseDTO(final Store store,final int reviewCount, final double reviewRatingAverage) {
+        return StoreResponseDTO.of(store.getStoreId(), store.getStoreImgUrl(), store.getStoreName(), store.getStoreLocation(), reviewCount ,reviewRatingAverage , store.getLatitude(), store.getLongitude());
+    }
+}

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/global/exception/CommonExceptionType.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/global/exception/CommonExceptionType.java
@@ -1,0 +1,39 @@
+package com.SMWU.CarryUsServer.global.exception;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public enum CommonExceptionType implements ExceptionType {
+    /**
+     * 404 Not Found
+     */
+    NOT_FOUND_PATH(HttpStatus.NOT_FOUND, "요청하신 경로를 찾을 수 없습니다"),
+
+    /**
+     * 500 Internal Server Error
+     */
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다."),
+
+    // 400 Bad Request
+    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "입력값이 올바르지 않습니다"),
+    // 415 UNSUPPORTED_MEDIA_TYPE
+    INVALID_JSON_TYPE(HttpStatus.UNSUPPORTED_MEDIA_TYPE, "올바른 요청 형식이 아닙니다")
+    ;
+
+    private final HttpStatus status;
+    private final String message;
+
+    @Override
+    public HttpStatus status() {
+        return this.status;
+    }
+
+    @Override
+    public String message() {
+        return this.message;
+    }
+}

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/global/exception/GlobalExceptionHandler.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,52 @@
+package com.SMWU.CarryUsServer.global.exception;
+
+import com.SMWU.CarryUsServer.global.response.ErrorResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.HttpMediaTypeNotSupportedException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.servlet.NoHandlerFoundException;
+
+import static com.SMWU.CarryUsServer.global.exception.CommonExceptionType.*;
+
+@RestControllerAdvice
+@Slf4j
+public class GlobalExceptionHandler {
+    @ExceptionHandler({ClientException.class})
+    protected ResponseEntity<ErrorResponse> handleCustomException(ClientException ex) {
+        return ResponseEntity.status(ex.getExceptionType().status()).body(ErrorResponse.of(ex.getExceptionType()));
+    }
+
+    @ExceptionHandler({ServerException.class})
+    protected ResponseEntity<ErrorResponse> handleServerException(ServerException ex) {
+        log.error("🚨BusinessException occurred: {} 🚨", ex);
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ErrorResponse.of(INTERNAL_SERVER_ERROR));
+    }
+
+    @ExceptionHandler({Exception.class})
+    protected ResponseEntity<ErrorResponse> handleServerException(Exception ex) {
+        log.error("🚨InternalException occurred: {} 🚨", ex);
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ErrorResponse.of(INTERNAL_SERVER_ERROR));
+    }
+
+    @ExceptionHandler(NoHandlerFoundException.class)
+    protected ResponseEntity<ErrorResponse> handleNotFoundException(final NoHandlerFoundException ex) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(ErrorResponse.of(NOT_FOUND_PATH, ex.getRequestURL()));
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ErrorResponse> handleMethodArgumentTypeMismatchException(MethodArgumentTypeMismatchException ex){
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ErrorResponse.of(INVALID_INPUT_VALUE, ex.getMessage()));
+    }
+
+    @ExceptionHandler(HttpMediaTypeNotSupportedException.class)
+    public ResponseEntity<ErrorResponse> handleValidationExceptions(HttpMediaTypeNotSupportedException ex){
+        return ResponseEntity.status(HttpStatus.UNSUPPORTED_MEDIA_TYPE).body(ErrorResponse.of(INVALID_JSON_TYPE, ex.getMessage()));
+    }
+}

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/global/response/SuccessResponse.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/global/response/SuccessResponse.java
@@ -10,7 +10,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor
 public class SuccessResponse<T> {
-    private final int code;
+    private final int status;
+    private final boolean success = true;
     private final String message;
     private T data;
 

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/global/security/config/SecurityConfig.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/global/security/config/SecurityConfig.java
@@ -4,7 +4,6 @@ import com.SMWU.CarryUsServer.global.security.filter.JwtAuthenticationFilter;
 import com.SMWU.CarryUsServer.global.security.filter.JwtExceptionFilter;
 import com.SMWU.CarryUsServer.global.security.handler.CustomAccessDeniedHandler;
 import com.SMWU.CarryUsServer.global.security.handler.CustomAuthenticationEntryPoint;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -64,7 +63,8 @@ public class SecurityConfig {
         http.authorizeHttpRequests(auth -> {
                     auth.requestMatchers(AUTH_WHITELIST).permitAll();
                     auth.requestMatchers(AUTH_WHITELIST_WILDCARD).permitAll();
-                    auth.requestMatchers("/main/**", "/search/**", "/stores/**", "/reservation/**", "/my/**", "/reviews/**").hasRole("TRAVELER");
+                    auth.requestMatchers("/stores/{storeId}/reservation", "/reservation/**", "/my/**", "/reviews/**").hasRole("TRAVELER");
+                    auth.requestMatchers("/main/**", "/search/**", "/stores/**").permitAll();
                     auth.anyRequest().authenticated();
                 })
               .exceptionHandling(exceptionConfig ->


### PR DESCRIPTION
## 🛄 PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🛄 반영 브랜치
<!-- feat/login -> dev와 같이 반영 브랜치를 표시합니다 -->
- feat/#23 -> dev
- closed #23

## 🛄 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 사용자의 현재 위치와 지도의 위도 경도 최대/최소 범위를 통해 주변 가게를 리스트로 반환합니다

## 🛄 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
<img width="844" alt="image" src="https://github.com/CARRY-US/CarryUs-Server/assets/81363864/8769019f-bbf4-40ff-888b-5be1feea1b98">


## 🛄 MEMO
<!-- 메모를 기록합니다 -->
