### PR TITLE
[FEAT] 위치에 따른 가게 리스트 조회

### DIFF
--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/store/controller/MainController.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/store/controller/MainController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
+import static com.SMWU.CarryUsServer.domain.store.exception.StoreSuccessType.GET_STORE_LIST_BY_LOCATION;
 import static com.SMWU.CarryUsServer.domain.store.exception.StoreSuccessType.GET_STORE_LIST_BY_MEMBER_LOCATION;
 
 @RestController
@@ -35,6 +36,6 @@ public class MainController {
             @RequestParam final double x,
             @RequestParam final double y){
         final List<StoreResponseDTO> responseDTO = storeService.getStoreListByLocation(x, y);
-        return ResponseEntity.ok(SuccessResponse.of(GET_STORE_LIST_BY_MEMBER_LOCATION, responseDTO));
+        return ResponseEntity.ok(SuccessResponse.of(GET_STORE_LIST_BY_LOCATION, responseDTO));
     }
 }

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/store/controller/MainController.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/store/controller/MainController.java
@@ -30,4 +30,11 @@ public class MainController {
         return ResponseEntity.ok(SuccessResponse.of(GET_STORE_LIST_BY_MEMBER_LOCATION, responseDTO));
     }
 
+    @GetMapping("/stores")
+    public ResponseEntity<SuccessResponse<List<StoreResponseDTO>>> getStoreListByLocation(
+            @RequestParam final double x,
+            @RequestParam final double y){
+        final List<StoreResponseDTO> responseDTO = storeService.getStoreListByLocation(x, y);
+        return ResponseEntity.ok(SuccessResponse.of(GET_STORE_LIST_BY_MEMBER_LOCATION, responseDTO));
+    }
 }

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/store/controller/response/StoreResponseDTO.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/store/controller/response/StoreResponseDTO.java
@@ -1,5 +1,7 @@
 package com.SMWU.CarryUsServer.domain.store.controller.response;
 
+import com.SMWU.CarryUsServer.domain.store.entity.Store;
+
 public record StoreResponseDTO(
         long storeId,
         String storeImgUrl,
@@ -11,5 +13,9 @@ public record StoreResponseDTO(
         double longitude) {
     public static StoreResponseDTO of(long storeId, String storeImgUrl, String storeName, String storeLocation, int storeReviewCount, double storeRatingAverage, double latitude, double longitude){
         return new StoreResponseDTO(storeId, storeImgUrl, storeName, storeLocation, storeReviewCount, storeRatingAverage, latitude, longitude);
+    }
+
+    public static StoreResponseDTO toStoreResponseDTO(final Store store, final int reviewCount, final double reviewRatingAverage) {
+        return StoreResponseDTO.of(store.getStoreId(), store.getStoreImgUrl(), store.getStoreName(), store.getStoreLocation(), reviewCount ,reviewRatingAverage , store.getLatitude(), store.getLongitude());
     }
 }

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/store/exception/StoreSuccessType.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/store/exception/StoreSuccessType.java
@@ -6,7 +6,8 @@ import org.springframework.http.HttpStatus;
 
 @RequiredArgsConstructor
 public enum StoreSuccessType implements SuccessType {
-    GET_STORE_LIST_BY_MEMBER_LOCATION(HttpStatus.OK, "사용자 위치 기반 가게 목록 조회에 성공하였습니다.");
+    GET_STORE_LIST_BY_MEMBER_LOCATION(HttpStatus.OK, "사용자 위치 기반 가게 목록 조회에 성공하였습니다."),
+    GET_STORE_LIST_BY_LOCATION(HttpStatus.OK, "특정 위치에 따른 가게 목록 조회에 성공하였습니다");
 
     private final HttpStatus status;
     private final String message;

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/store/repository/StoreRepository.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/store/repository/StoreRepository.java
@@ -6,5 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface StoreRepository extends JpaRepository<Store, Long>{
-    List<Store> findByLatitudeBetweenAndLongitudeBetweenOrderByStoreId(double xMin, double xMax, double yMin, double yMax);
+    List<Store> findAllByLatitudeBetweenAndLongitudeBetweenOrderByStoreId(final double xMin, final double xMax, final double yMin, final double yMax);
+
+    List<Store> findAllByLatitudeAndLongitude(final double x, final double y);
 }

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/store/service/StoreService.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/store/service/StoreService.java
@@ -11,6 +11,8 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.SMWU.CarryUsServer.domain.store.controller.response.StoreResponseDTO.toStoreResponseDTO;
+
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -20,17 +22,22 @@ public class StoreService {
     public static final double EMPTY_RATING = 0.0;
 
     public List<StoreResponseDTO> getStoreListByMemberLocation(final double xMin, final double xMax, final double yMin, final double yMax) {
-        final List<Store> storeList = storeRepository.findByLatitudeBetweenAndLongitudeBetweenOrderByStoreId(xMin, xMax, yMin, yMax);
+        final List<Store> storeList = storeRepository.findAllByLatitudeBetweenAndLongitudeBetweenOrderByStoreId(xMin, xMax, yMin, yMax);
+        return getStoreResponseDTOList(storeList);
+    }
+
+    public List<StoreResponseDTO> getStoreListByLocation(final double x, final double y){
+        final List<Store> storeList = storeRepository.findAllByLatitudeAndLongitude(x, y);
+        return getStoreResponseDTOList(storeList);
+    }
+
+    private List<StoreResponseDTO> getStoreResponseDTOList(List<Store> storeList){
         List<StoreResponseDTO> responseDTOList = new ArrayList<>();
         for(Store store : storeList) {
             final int reviewCount = reviewRepository.getReviewCount(store.getStoreId());
-        final double reviewRating = reviewRepository.getStoreRating(store.getStoreId()).orElse(EMPTY_RATING);
-            responseDTOList.add(toResponseDTO(store, reviewCount, reviewRating));
+            final double reviewRating = reviewRepository.getStoreRating(store.getStoreId()).orElse(EMPTY_RATING);
+            responseDTOList.add(toStoreResponseDTO(store, reviewCount, reviewRating));
         }
         return responseDTOList;
-    }
-
-    private StoreResponseDTO toResponseDTO(final Store store,final int reviewCount, final double reviewRatingAverage) {
-        return StoreResponseDTO.of(store.getStoreId(), store.getStoreImgUrl(), store.getStoreName(), store.getStoreLocation(), reviewCount ,reviewRatingAverage , store.getLatitude(), store.getLongitude());
     }
 }


### PR DESCRIPTION
## 🛄 PR 타입
- [x] 기능 추가
- [x] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🛄 반영 브랜치
<!-- feat/login -> dev와 같이 반영 브랜치를 표시합니다 -->
- feat/#29 -> dev
- closed #29

## 🛄 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 위치(특정 위도, 경도)에 따른 가게 리스트 조회 구현 기능을 개발했습니다

## 🛄 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
<img width="848" alt="image" src="https://github.com/CARRY-US/CarryUs-Server/assets/81363864/0be4f051-79a0-4293-b7f1-3a82dc31dfef">

## 🛄 MEMO
<!-- 메모를 기록합니다 -->
