### PR TITLE
[FEAT] 가게 위치(구) 기반 검색 구현

### DIFF
--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/store/controller/SearchController.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/store/controller/SearchController.java
@@ -1,0 +1,28 @@
+package com.SMWU.CarryUsServer.domain.store.controller;
+
+import com.SMWU.CarryUsServer.domain.store.controller.response.StoreResponseDTO;
+import com.SMWU.CarryUsServer.domain.store.service.StoreService;
+import com.SMWU.CarryUsServer.global.response.SuccessResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+import static com.SMWU.CarryUsServer.domain.store.exception.StoreSuccessType.GET_STORE_LIST_BY_SEARCH;
+
+@RestController
+@RequestMapping("/search")
+@RequiredArgsConstructor
+public class SearchController {
+    private final StoreService storeService;
+
+    @GetMapping("")
+    public ResponseEntity<SuccessResponse<List<StoreResponseDTO>>> getStoreListByCity(@RequestParam final String word){
+        List<StoreResponseDTO> responseDTO = storeService.getStoreListByCity(word);
+        return ResponseEntity.ok(SuccessResponse.of(GET_STORE_LIST_BY_SEARCH, responseDTO));
+    }
+}

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/store/exception/StoreSuccessType.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/store/exception/StoreSuccessType.java
@@ -7,7 +7,9 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum StoreSuccessType implements SuccessType {
     GET_STORE_LIST_BY_MEMBER_LOCATION(HttpStatus.OK, "사용자 위치 기반 가게 목록 조회에 성공하였습니다."),
-    GET_STORE_LIST_BY_LOCATION(HttpStatus.OK, "특정 위치에 따른 가게 목록 조회에 성공하였습니다");
+    GET_STORE_LIST_BY_LOCATION(HttpStatus.OK, "특정 위치에 따른 가게 목록 조회에 성공하였습니다"),
+
+    GET_STORE_LIST_BY_SEARCH(HttpStatus.OK, "검색에 따른 가게 목록 조회에 성공하였습니다");
 
     private final HttpStatus status;
     private final String message;

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/store/exception/StoreSuccessType.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/store/exception/StoreSuccessType.java
@@ -8,7 +8,6 @@ import org.springframework.http.HttpStatus;
 public enum StoreSuccessType implements SuccessType {
     GET_STORE_LIST_BY_MEMBER_LOCATION(HttpStatus.OK, "사용자 위치 기반 가게 목록 조회에 성공하였습니다."),
     GET_STORE_LIST_BY_LOCATION(HttpStatus.OK, "특정 위치에 따른 가게 목록 조회에 성공하였습니다"),
-
     GET_STORE_LIST_BY_SEARCH(HttpStatus.OK, "검색에 따른 가게 목록 조회에 성공하였습니다");
 
     private final HttpStatus status;

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/store/repository/StoreRepository.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/store/repository/StoreRepository.java
@@ -9,4 +9,6 @@ public interface StoreRepository extends JpaRepository<Store, Long>{
     List<Store> findAllByLatitudeBetweenAndLongitudeBetweenOrderByStoreId(final double xMin, final double xMax, final double yMin, final double yMax);
 
     List<Store> findAllByLatitudeAndLongitude(final double x, final double y);
+
+    List<Store> findAllByCity(final String city);
 }

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/store/service/StoreService.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/store/service/StoreService.java
@@ -31,6 +31,11 @@ public class StoreService {
         return getStoreResponseDTOList(storeList);
     }
 
+    public List<StoreResponseDTO> getStoreListByCity(final String city){
+        final List<Store> storeList = storeRepository.findAllByCity(city);
+        return getStoreResponseDTOList(storeList);
+    }
+
     private List<StoreResponseDTO> getStoreResponseDTOList(List<Store> storeList){
         List<StoreResponseDTO> responseDTOList = new ArrayList<>();
         for(Store store : storeList) {


### PR DESCRIPTION
## 🛄 PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🛄 반영 브랜치
<!-- feat/login -> dev와 같이 반영 브랜치를 표시합니다 -->
- feat/#31 -> dev
- closed #31

## 🛄 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 행정구역 '구'를 기준으로 가게 리스트를 검색하는 기능을 개발했습니다

## 🛄 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
<img width="846" alt="image" src="https://github.com/CARRY-US/CarryUs-Server/assets/81363864/e370d027-30ce-402e-8d9e-c98cd0112600">


## 🛄 MEMO
<!-- 메모를 기록합니다 -->
