### PR TITLE
[FEAT] 가게 리뷰 리스트 조회 기능

### DIFF
--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/member/controller/response/MemberReviewResponseDTO.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/member/controller/response/MemberReviewResponseDTO.java
@@ -11,7 +11,7 @@ public record MemberReviewResponseDTO(
         return new MemberReviewResponseDTO(reviewId, storeName, reviewRating, reviewContent);
     }
 
-    public static MemberReviewResponseDTO toMemberReviewResponseDTO(final ReservationReview reservationReview, final String storeName) {
+    public static MemberReviewResponseDTO getMemberReviewResponseDTO(final ReservationReview reservationReview, final String storeName) {
         return MemberReviewResponseDTO.of(reservationReview.getReservationReviewId(), storeName, reservationReview.getReviewRating(), reservationReview.getReviewContent());
     }
 }

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/member/controller/response/MemberReviewResponseDTO.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/member/controller/response/MemberReviewResponseDTO.java
@@ -1,5 +1,7 @@
 package com.SMWU.CarryUsServer.domain.member.controller.response;
 
+import com.SMWU.CarryUsServer.domain.reservation.entity.ReservationReview;
+
 public record MemberReviewResponseDTO(
         long reviewId,
         String storeName,
@@ -7,5 +9,9 @@ public record MemberReviewResponseDTO(
         String reviewContent) {
     public static MemberReviewResponseDTO of(long reviewId, String storeName, double reviewRating, String reviewContent) {
         return new MemberReviewResponseDTO(reviewId, storeName, reviewRating, reviewContent);
+    }
+
+    public static MemberReviewResponseDTO toMemberReviewResponseDTO(final ReservationReview reservationReview, final String storeName) {
+        return MemberReviewResponseDTO.of(reservationReview.getReservationReviewId(), storeName, reservationReview.getReviewRating(), reservationReview.getReviewContent());
     }
 }

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/controller/response/ReviewResponseDTO.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/controller/response/ReviewResponseDTO.java
@@ -10,7 +10,7 @@ public record ReviewResponseDTO(
         return new ReviewResponseDTO(reviewId, reviewRating, reviewContent);
     }
 
-    public static ReviewResponseDTO toReviewResponseDTO(final ReservationReview reservationReview){
+    public static ReviewResponseDTO getReviewResponseDTO(final ReservationReview reservationReview){
         return ReviewResponseDTO.of(reservationReview.getReservationReviewId(), reservationReview.getReviewRating(), reservationReview.getReviewContent());
     }
 }

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/controller/response/ReviewResponseDTO.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/controller/response/ReviewResponseDTO.java
@@ -1,10 +1,16 @@
 package com.SMWU.CarryUsServer.domain.reservation.controller.response;
 
+import com.SMWU.CarryUsServer.domain.reservation.entity.ReservationReview;
+
 public record ReviewResponseDTO(
         long reviewId,
         double reviewRating,
         String reviewContent) {
     public static ReviewResponseDTO of(long reviewId, double reviewRating, String reviewContent) {
         return new ReviewResponseDTO(reviewId, reviewRating, reviewContent);
+    }
+
+    public static ReviewResponseDTO toReviewResponseDTO(final ReservationReview reservationReview){
+        return ReviewResponseDTO.of(reservationReview.getReservationReviewId(), reservationReview.getReviewRating(), reservationReview.getReviewContent());
     }
 }

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/controller/response/StoreReviewResponseDTO.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/controller/response/StoreReviewResponseDTO.java
@@ -1,0 +1,26 @@
+package com.SMWU.CarryUsServer.domain.reservation.controller.response;
+
+import com.SMWU.CarryUsServer.domain.reservation.entity.ReservationReview;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+public record StoreReviewResponseDTO(
+        long reviewId,
+        String memberName,
+        String reviewCreatedAt,
+        double reviewRating,
+        String reviewText
+        ) {
+    public static StoreReviewResponseDTO of(long reviewId, String memberName, String reviewCreatedAt, double reviewRating, String reviewText) {
+        return new StoreReviewResponseDTO(reviewId, memberName, reviewCreatedAt, reviewRating, reviewText);
+    }
+
+    public static StoreReviewResponseDTO toStoreReviewResponseDTO(final ReservationReview reservationReview){
+        return StoreReviewResponseDTO.of(reservationReview.getReservationReviewId(), reservationReview.getReservation().getClient().getName(), getReviewCreatedAt(reservationReview.getCreatedAt()), reservationReview.getReviewRating(), reservationReview.getReviewContent());
+    }
+
+    private static String getReviewCreatedAt(final LocalDateTime createdAt) {
+        return createdAt.format(DateTimeFormatter.ofPattern("yyyy.MM.dd"));
+    }
+}

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/controller/response/StoreReviewResponseDTO.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/controller/response/StoreReviewResponseDTO.java
@@ -17,7 +17,9 @@ public record StoreReviewResponseDTO(
     }
 
     public static StoreReviewResponseDTO getStoreReviewResponseDTO(final ReservationReview reservationReview){
-        return StoreReviewResponseDTO.of(reservationReview.getReservationReviewId(), reservationReview.getReservation().getClient().getName(), getReviewCreatedAt(reservationReview.getCreatedAt()), reservationReview.getReviewRating(), reservationReview.getReviewContent());
+        String memberName = reservationReview.getReservation().getClient().getName();
+        String reviewCreatedAt = getReviewCreatedAt(reservationReview.getCreatedAt());
+        return StoreReviewResponseDTO.of(reservationReview.getReservationReviewId(), memberName, reviewCreatedAt, reservationReview.getReviewRating(), reservationReview.getReviewContent());
     }
 
     private static String getReviewCreatedAt(final LocalDateTime createdAt) {

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/controller/response/StoreReviewResponseDTO.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/controller/response/StoreReviewResponseDTO.java
@@ -16,7 +16,7 @@ public record StoreReviewResponseDTO(
         return new StoreReviewResponseDTO(reviewId, memberName, reviewCreatedAt, reviewRating, reviewText);
     }
 
-    public static StoreReviewResponseDTO toStoreReviewResponseDTO(final ReservationReview reservationReview){
+    public static StoreReviewResponseDTO getStoreReviewResponseDTO(final ReservationReview reservationReview){
         return StoreReviewResponseDTO.of(reservationReview.getReservationReviewId(), reservationReview.getReservation().getClient().getName(), getReviewCreatedAt(reservationReview.getCreatedAt()), reservationReview.getReviewRating(), reservationReview.getReviewContent());
     }
 

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/controller/response/StoreReviewResponseListDTO.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/controller/response/StoreReviewResponseListDTO.java
@@ -1,0 +1,12 @@
+package com.SMWU.CarryUsServer.domain.reservation.controller.response;
+
+import java.util.List;
+
+public record StoreReviewResponseListDTO(
+        double reviewRatingAverage,
+        List<StoreReviewResponseDTO> reviewList
+) {
+    public static StoreReviewResponseListDTO of(double reviewRatingAverage, List<StoreReviewResponseDTO> reviewList) {
+        return new StoreReviewResponseListDTO(reviewRatingAverage, reviewList);
+    }
+}

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/repository/ReservationReviewRepository.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/repository/ReservationReviewRepository.java
@@ -20,4 +20,7 @@ public interface ReservationReviewRepository extends JpaRepository<ReservationRe
 
     @Query("SELECT COUNT(rr) FROM ReservationReview rr JOIN rr.reservation r WHERE r.store.storeId = :storeId")
     int getReviewCount(@Param("storeId") Long storeId);
+
+    @Query("SELECT rr FROM ReservationReview rr JOIN FETCH rr.reservation r WHERE r.store.storeId =:storeId")
+    List<ReservationReview> getReservationReviewByStore(@Param("storeId") Long storeId);
 }

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/service/ReservationReviewService.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/service/ReservationReviewService.java
@@ -20,7 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static com.SMWU.CarryUsServer.domain.member.controller.response.MemberReviewResponseDTO.getMemberReviewResponseDTO;
-import static com.SMWU.CarryUsServer.domain.reservation.controller.response.ReviewResponseDTO.toReviewResponseDTO;
+import static com.SMWU.CarryUsServer.domain.reservation.controller.response.ReviewResponseDTO.getReviewResponseDTO;
 import static com.SMWU.CarryUsServer.domain.reservation.controller.response.StoreReviewResponseDTO.toStoreReviewResponseDTO;
 import static com.SMWU.CarryUsServer.domain.reservation.exception.ReservationExceptionType.NOT_COMPLETED_RESERVATION;
 import static com.SMWU.CarryUsServer.domain.reservation.exception.ReservationExceptionType.NOT_FOUND_RESERVATION;
@@ -64,7 +64,7 @@ public class ReservationReviewService {
     public ReviewResponseDTO getReviewDetail(final Long reviewId, final Member member) {
         final ReservationReview reservationReview = reservationReviewRepository.findByReservationReviewIdAndReservationClient(reviewId, member)
                 .orElseThrow(() -> new ReviewException(NOT_FOUND_REVIEW));
-        return toReviewResponseDTO(reservationReview);
+        return getReviewResponseDTO(reservationReview);
     }
 
     public ReservationStoreInfoResponseDTO getReservationStoreInfo(final Long reviewId, final Member member){

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/service/ReservationReviewService.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/service/ReservationReviewService.java
@@ -21,7 +21,7 @@ import java.util.List;
 
 import static com.SMWU.CarryUsServer.domain.member.controller.response.MemberReviewResponseDTO.getMemberReviewResponseDTO;
 import static com.SMWU.CarryUsServer.domain.reservation.controller.response.ReviewResponseDTO.getReviewResponseDTO;
-import static com.SMWU.CarryUsServer.domain.reservation.controller.response.StoreReviewResponseDTO.toStoreReviewResponseDTO;
+import static com.SMWU.CarryUsServer.domain.reservation.controller.response.StoreReviewResponseDTO.getStoreReviewResponseDTO;
 import static com.SMWU.CarryUsServer.domain.reservation.exception.ReservationExceptionType.NOT_COMPLETED_RESERVATION;
 import static com.SMWU.CarryUsServer.domain.reservation.exception.ReservationExceptionType.NOT_FOUND_RESERVATION;
 import static com.SMWU.CarryUsServer.domain.reservation.exception.ReviewExceptiontype.NOT_FOUND_REVIEW;
@@ -56,7 +56,7 @@ public class ReservationReviewService {
     private List<StoreReviewResponseDTO> toStoreReviewList(final List<ReservationReview> reservationReviewList) {
         List<StoreReviewResponseDTO> storeReviewListResponseDTO = new ArrayList<>();
         for (ReservationReview reservationReview : reservationReviewList) {
-            storeReviewListResponseDTO.add(toStoreReviewResponseDTO(reservationReview));
+            storeReviewListResponseDTO.add(getStoreReviewResponseDTO(reservationReview));
         }
         return storeReviewListResponseDTO;
     }

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/service/ReservationReviewService.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/service/ReservationReviewService.java
@@ -19,7 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.SMWU.CarryUsServer.domain.member.controller.response.MemberReviewResponseDTO.toMemberReviewResponseDTO;
+import static com.SMWU.CarryUsServer.domain.member.controller.response.MemberReviewResponseDTO.getMemberReviewResponseDTO;
 import static com.SMWU.CarryUsServer.domain.reservation.controller.response.ReviewResponseDTO.toReviewResponseDTO;
 import static com.SMWU.CarryUsServer.domain.reservation.controller.response.StoreReviewResponseDTO.toStoreReviewResponseDTO;
 import static com.SMWU.CarryUsServer.domain.reservation.exception.ReservationExceptionType.NOT_COMPLETED_RESERVATION;
@@ -41,7 +41,7 @@ public class ReservationReviewService {
     private List<MemberReviewResponseDTO> getMemberReviewResponseDTOList(final List<ReservationReview> reservationReviewList){
         List<MemberReviewResponseDTO> memberReviewListResponseDTO = new ArrayList<>();
         for (ReservationReview reservationReview : reservationReviewList) {
-            memberReviewListResponseDTO.add(toMemberReviewResponseDTO(reservationReview, reservationReview.getReservation().getStore().getStoreName()));
+            memberReviewListResponseDTO.add(getMemberReviewResponseDTO(reservationReview, reservationReview.getReservation().getStore().getStoreName()));
         }
         return memberReviewListResponseDTO;
     }

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/store/controller/StoreController.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/store/controller/StoreController.java
@@ -2,7 +2,6 @@ package com.SMWU.CarryUsServer.domain.store.controller;
 
 import com.SMWU.CarryUsServer.domain.reservation.controller.response.StoreReviewResponseListDTO;
 import com.SMWU.CarryUsServer.domain.reservation.service.ReservationReviewService;
-import com.SMWU.CarryUsServer.domain.store.service.StoreService;
 import com.SMWU.CarryUsServer.global.response.SuccessResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/store/controller/StoreController.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/store/controller/StoreController.java
@@ -1,0 +1,26 @@
+package com.SMWU.CarryUsServer.domain.store.controller;
+
+import com.SMWU.CarryUsServer.domain.reservation.controller.response.StoreReviewResponseListDTO;
+import com.SMWU.CarryUsServer.domain.reservation.service.ReservationReviewService;
+import com.SMWU.CarryUsServer.domain.store.service.StoreService;
+import com.SMWU.CarryUsServer.global.response.SuccessResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.SMWU.CarryUsServer.domain.store.exception.StoreSuccessType.GET_STORE_REVIEW_LIST;
+
+@RestController
+@RequestMapping("/stores")
+@RequiredArgsConstructor
+public class StoreController {
+    private final ReservationReviewService reservationReviewService;
+
+    @GetMapping("/{storeId}/reviews")
+    public ResponseEntity<SuccessResponse<StoreReviewResponseListDTO>> getStoreReviewList(@PathVariable final long storeId) {
+        return ResponseEntity.ok().body(SuccessResponse.of(GET_STORE_REVIEW_LIST, reservationReviewService.getStoreReviewList(storeId)));
+    }
+}

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/store/exception/StoreSuccessType.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/store/exception/StoreSuccessType.java
@@ -8,7 +8,8 @@ import org.springframework.http.HttpStatus;
 public enum StoreSuccessType implements SuccessType {
     GET_STORE_LIST_BY_MEMBER_LOCATION(HttpStatus.OK, "사용자 위치 기반 가게 목록 조회에 성공하였습니다."),
     GET_STORE_LIST_BY_LOCATION(HttpStatus.OK, "특정 위치에 따른 가게 목록 조회에 성공하였습니다"),
-    GET_STORE_LIST_BY_SEARCH(HttpStatus.OK, "검색에 따른 가게 목록 조회에 성공하였습니다");
+    GET_STORE_LIST_BY_SEARCH(HttpStatus.OK, "검색에 따른 가게 목록 조회에 성공하였습니다"),
+    GET_STORE_REVIEW_LIST(HttpStatus.OK, "가게 리뷰 목록 조회에 성공하였습니다");
 
     private final HttpStatus status;
     private final String message;


### PR DESCRIPTION
## 🛄 PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🛄 반영 브랜치
<!-- feat/login -> dev와 같이 반영 브랜치를 표시합니다 -->
- feat/#33 -> dev
- closed #33

## 🛄 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 가게 리뷰 리스트 조회 기능 구현

## 🛄 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
<img width="842" alt="image" src="https://github.com/CARRY-US/CarryUs-Server/assets/81363864/02ed4e68-bbc4-4fec-af7f-4b956488438c">


## 🛄 MEMO
<!-- 메모를 기록합니다 -->
