### PR TITLE
[FEAT] 가게 상세정보 조회 구현

### DIFF
--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/store/controller/StoreController.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/store/controller/StoreController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import static com.SMWU.CarryUsServer.domain.store.exception.StoreSuccessType.GET_STORE_DETAIL;
 import static com.SMWU.CarryUsServer.domain.store.exception.StoreSuccessType.GET_STORE_REVIEW_LIST;
 
 @RestController
@@ -30,6 +31,6 @@ public class StoreController {
     @GetMapping("/{storeId}/detail")
     public ResponseEntity<SuccessResponse<StoreDetailResponseDTO>> getStoreDetail(@PathVariable final long storeId) {
         StoreDetailResponseDTO responseDTO = storeService.getStoreDetail(storeId);
-        return ResponseEntity.ok().body(SuccessResponse.of(GET_STORE_REVIEW_LIST, responseDTO));
+        return ResponseEntity.ok().body(SuccessResponse.of(GET_STORE_DETAIL, responseDTO));
     }
 }

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/store/controller/StoreController.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/store/controller/StoreController.java
@@ -2,6 +2,8 @@ package com.SMWU.CarryUsServer.domain.store.controller;
 
 import com.SMWU.CarryUsServer.domain.reservation.controller.response.StoreReviewResponseListDTO;
 import com.SMWU.CarryUsServer.domain.reservation.service.ReservationReviewService;
+import com.SMWU.CarryUsServer.domain.store.controller.response.StoreDetailResponseDTO;
+import com.SMWU.CarryUsServer.domain.store.service.StoreService;
 import com.SMWU.CarryUsServer.global.response.SuccessResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -17,9 +19,17 @@ import static com.SMWU.CarryUsServer.domain.store.exception.StoreSuccessType.GET
 @RequiredArgsConstructor
 public class StoreController {
     private final ReservationReviewService reservationReviewService;
+    private final StoreService storeService;
 
     @GetMapping("/{storeId}/reviews")
     public ResponseEntity<SuccessResponse<StoreReviewResponseListDTO>> getStoreReviewList(@PathVariable final long storeId) {
-        return ResponseEntity.ok().body(SuccessResponse.of(GET_STORE_REVIEW_LIST, reservationReviewService.getStoreReviewList(storeId)));
+        StoreReviewResponseListDTO responseDTO = reservationReviewService.getStoreReviewList(storeId);
+        return ResponseEntity.ok().body(SuccessResponse.of(GET_STORE_REVIEW_LIST, responseDTO));
+    }
+
+    @GetMapping("/{storeId}/detail")
+    public ResponseEntity<SuccessResponse<StoreDetailResponseDTO>> getStoreDetail(@PathVariable final long storeId) {
+        StoreDetailResponseDTO responseDTO = storeService.getStoreDetail(storeId);
+        return ResponseEntity.ok().body(SuccessResponse.of(GET_STORE_REVIEW_LIST, responseDTO));
     }
 }

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/store/controller/response/BaggageTypeInfoResponseDTO.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/store/controller/response/BaggageTypeInfoResponseDTO.java
@@ -1,0 +1,16 @@
+package com.SMWU.CarryUsServer.domain.store.controller.response;
+
+import com.SMWU.CarryUsServer.domain.store.entity.StoreBaggage;
+
+public record BaggageTypeInfoResponseDTO(
+        String baggageType,
+        int baggageCount,
+        int baggagePrice) {
+    public static BaggageTypeInfoResponseDTO of(String baggageType, int baggageCount, int baggagePrice) {
+        return new BaggageTypeInfoResponseDTO(baggageType, baggageCount, baggagePrice);
+    }
+
+    public static BaggageTypeInfoResponseDTO getBaggageTypeInfoResponseDTO(StoreBaggage storeBaggage){
+        return BaggageTypeInfoResponseDTO.of(storeBaggage.getBaggageType().getMessage(), storeBaggage.getBaggageCount(), storeBaggage.getBaggagePrice());
+    }
+}

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/store/controller/response/StoreDetailResponseDTO.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/store/controller/response/StoreDetailResponseDTO.java
@@ -1,0 +1,24 @@
+package com.SMWU.CarryUsServer.domain.store.controller.response;
+
+import com.SMWU.CarryUsServer.domain.store.entity.Store;
+
+import java.util.List;
+
+public record StoreDetailResponseDTO(
+        long storeId,
+        String storeImgUrl,
+        String storeName,
+        String storeLocation,
+        String closedDay,
+        String openingHour,
+        String storePhoneNumber,
+        List<BaggageTypeInfoResponseDTO> baggageTypeInfoList
+) {
+    public static StoreDetailResponseDTO of(long storeId, String storeImgUrl, String storeName, String storeLocation, String closedDay, String openingHour, String storePhoneNumber, List<BaggageTypeInfoResponseDTO> baggageTypeInfoList) {
+        return new StoreDetailResponseDTO(storeId, storeImgUrl, storeName, storeLocation, closedDay, openingHour, storePhoneNumber, baggageTypeInfoList);
+    }
+
+    public static StoreDetailResponseDTO getStoreDetailResponseDTO(final Store store, List<BaggageTypeInfoResponseDTO> baggageTypeInfoList){
+        return StoreDetailResponseDTO.of(store.getStoreId(), store.getStoreImgUrl(), store.getStoreName(), store.getStoreLocation(), store.getClosedDay(), store.getOpeningHour(), store.getStorePhoneNumber(), baggageTypeInfoList);
+    }
+}

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/store/exception/StoreSuccessType.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/store/exception/StoreSuccessType.java
@@ -9,7 +9,8 @@ public enum StoreSuccessType implements SuccessType {
     GET_STORE_LIST_BY_MEMBER_LOCATION(HttpStatus.OK, "사용자 위치 기반 가게 목록 조회에 성공하였습니다."),
     GET_STORE_LIST_BY_LOCATION(HttpStatus.OK, "특정 위치에 따른 가게 목록 조회에 성공하였습니다"),
     GET_STORE_LIST_BY_SEARCH(HttpStatus.OK, "검색에 따른 가게 목록 조회에 성공하였습니다"),
-    GET_STORE_REVIEW_LIST(HttpStatus.OK, "가게 리뷰 목록 조회에 성공하였습니다");
+    GET_STORE_REVIEW_LIST(HttpStatus.OK, "가게 리뷰 목록 조회에 성공하였습니다"),
+    GET_STORE_DETAIL(HttpStatus.OK, "가게 상세 정보 조회에 성공하였습니다"),;
 
     private final HttpStatus status;
     private final String message;

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/store/repository/StoreBaggageRepository.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/store/repository/StoreBaggageRepository.java
@@ -1,0 +1,11 @@
+package com.SMWU.CarryUsServer.domain.store.repository;
+
+import com.SMWU.CarryUsServer.domain.store.entity.Store;
+import com.SMWU.CarryUsServer.domain.store.entity.StoreBaggage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface StoreBaggageRepository extends JpaRepository<StoreBaggage, Long> {
+    List<StoreBaggage> findAllByStoreOrderByStoreBaggageIdAsc(Store store);
+}

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/store/service/StoreService.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/store/service/StoreService.java
@@ -1,8 +1,12 @@
 package com.SMWU.CarryUsServer.domain.store.service;
 
 import com.SMWU.CarryUsServer.domain.reservation.repository.ReservationReviewRepository;
+import com.SMWU.CarryUsServer.domain.store.controller.response.BaggageTypeInfoResponseDTO;
+import com.SMWU.CarryUsServer.domain.store.controller.response.StoreDetailResponseDTO;
 import com.SMWU.CarryUsServer.domain.store.controller.response.StoreResponseDTO;
 import com.SMWU.CarryUsServer.domain.store.entity.Store;
+import com.SMWU.CarryUsServer.domain.store.entity.StoreBaggage;
+import com.SMWU.CarryUsServer.domain.store.repository.StoreBaggageRepository;
 import com.SMWU.CarryUsServer.domain.store.repository.StoreRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -11,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.SMWU.CarryUsServer.domain.store.controller.response.BaggageTypeInfoResponseDTO.getBaggageTypeInfoResponseDTO;
 import static com.SMWU.CarryUsServer.domain.store.controller.response.StoreResponseDTO.toStoreResponseDTO;
 
 @Service
@@ -19,6 +24,7 @@ import static com.SMWU.CarryUsServer.domain.store.controller.response.StoreRespo
 public class StoreService {
     private final StoreRepository storeRepository;
     private final ReservationReviewRepository reviewRepository;
+    private final StoreBaggageRepository storeBaggageRepository;
     public static final double EMPTY_RATING = 0.0;
 
     public List<StoreResponseDTO> getStoreListByMemberLocation(final double xMin, final double xMax, final double yMin, final double yMax) {
@@ -44,5 +50,20 @@ public class StoreService {
             responseDTOList.add(toStoreResponseDTO(store, reviewCount, reviewRating));
         }
         return responseDTOList;
+    }
+
+    public StoreDetailResponseDTO getStoreDetail(final long storeId) {
+        final Store store = storeRepository.findById(storeId).orElseThrow();
+        final List<BaggageTypeInfoResponseDTO> baggageTypeInfoList = getBaggageTypeInfoList(store);
+        return StoreDetailResponseDTO.getStoreDetailResponseDTO(store, baggageTypeInfoList);
+    }
+
+    private List<BaggageTypeInfoResponseDTO> getBaggageTypeInfoList(final Store store){
+        List<BaggageTypeInfoResponseDTO> baggageTypeInfoList = new ArrayList<>();
+        final List<StoreBaggage> storeBaggageList = storeBaggageRepository.findAllByStoreOrderByStoreBaggageIdAsc(store);
+        for(StoreBaggage storeBaggage : storeBaggageList){
+            baggageTypeInfoList.add(getBaggageTypeInfoResponseDTO(storeBaggage));
+        }
+        return baggageTypeInfoList;
     }
 }


### PR DESCRIPTION
## 🛄 PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🛄 반영 브랜치
<!-- feat/login -> dev와 같이 반영 브랜치를 표시합니다 -->
- feat/#35 -> dev
- closed #35

## 🛄 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 가게 상세정보를 조회하는 기능을 구현했습니다

## 🛄 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
<img width="835" alt="image" src="https://github.com/CARRY-US/CarryUs-Server/assets/81363864/54d22a80-f46b-4b31-90f9-1f18556d8a8d">


## 🛄 MEMO
<!-- 메모를 기록합니다 -->
