### PR TITLE
[FEAT] 사용자 예약 기본 정보 조회

### DIFF
--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/member/controller/response/MemberReservationDefaultInfoResponseDTO.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/member/controller/response/MemberReservationDefaultInfoResponseDTO.java
@@ -1,0 +1,16 @@
+package com.SMWU.CarryUsServer.domain.member.controller.response;
+
+import com.SMWU.CarryUsServer.domain.member.entity.Member;
+
+public record MemberReservationDefaultInfoResponseDTO(
+        String memberName,
+        String memberPhoneNumber
+) {
+    private static MemberReservationDefaultInfoResponseDTO of(final String memberName, final String memberPhoneNumber) {
+        return new MemberReservationDefaultInfoResponseDTO(memberName, memberPhoneNumber);
+    }
+
+    public static MemberReservationDefaultInfoResponseDTO getMemberReservationDefaultInfoResponseDTO (final Member member) {
+        return MemberReservationDefaultInfoResponseDTO.of(member.getName(), member.getPhoneNumber());
+    }
+}

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/member/service/MemberService.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/member/service/MemberService.java
@@ -1,6 +1,7 @@
 package com.SMWU.CarryUsServer.domain.member.service;
 
 import com.SMWU.CarryUsServer.domain.member.controller.response.MemberProfileResponseDTO;
+import com.SMWU.CarryUsServer.domain.member.controller.response.MemberReservationDefaultInfoResponseDTO;
 import com.SMWU.CarryUsServer.domain.member.entity.Member;
 import com.SMWU.CarryUsServer.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
@@ -11,9 +12,11 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class MemberService {
-    private final MemberRepository memberRepository;
-
     public MemberProfileResponseDTO getMemberProfile(final Member member) {
         return MemberProfileResponseDTO.of(member.getName(), member.getProfileImg());
+    }
+
+    public MemberReservationDefaultInfoResponseDTO getMemberReservationDefaultInfo(final Member member) {
+        return getMemberReservationDefaultInfo(member);
     }
 }

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/member/service/MemberService.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/member/service/MemberService.java
@@ -1,9 +1,8 @@
 package com.SMWU.CarryUsServer.domain.member.service;
 
 import com.SMWU.CarryUsServer.domain.member.controller.response.MemberProfileResponseDTO;
-import com.SMWU.CarryUsServer.domain.member.controller.response.MemberReservationDefaultInfoResponseDTO;
+import com.SMWU.CarryUsServer.domain.reservation.controller.response.MemberReservationDefaultInfoResponseDTO;
 import com.SMWU.CarryUsServer.domain.member.entity.Member;
-import com.SMWU.CarryUsServer.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/member/service/MemberService.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/member/service/MemberService.java
@@ -7,6 +7,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import static com.SMWU.CarryUsServer.domain.reservation.controller.response.MemberReservationDefaultInfoResponseDTO.getMemberReservationDefaultInfoResponseDTO;
+
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -16,6 +18,6 @@ public class MemberService {
     }
 
     public MemberReservationDefaultInfoResponseDTO getMemberReservationDefaultInfo(final Member member) {
-        return getMemberReservationDefaultInfo(member);
+        return getMemberReservationDefaultInfoResponseDTO(member);
     }
 }

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/controller/ReservationController.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/controller/ReservationController.java
@@ -1,7 +1,9 @@
 package com.SMWU.CarryUsServer.domain.reservation.controller;
 
 import com.SMWU.CarryUsServer.domain.member.entity.Member;
+import com.SMWU.CarryUsServer.domain.member.service.MemberService;
 import com.SMWU.CarryUsServer.domain.reservation.controller.request.ReviewCreateRequestDTO;
+import com.SMWU.CarryUsServer.domain.reservation.controller.response.MemberReservationDefaultInfoResponseDTO;
 import com.SMWU.CarryUsServer.domain.reservation.controller.response.ReviewIdResponseDTO;
 import com.SMWU.CarryUsServer.domain.reservation.service.ReservationReviewService;
 import com.SMWU.CarryUsServer.global.response.SuccessResponse;
@@ -10,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import static com.SMWU.CarryUsServer.domain.reservation.exception.ReservationSuccessType.RESERVATION_MEMBER_DEFAULT_INFO_GET_SUCCESS;
 import static com.SMWU.CarryUsServer.domain.reservation.exception.ReviewSuccessType.REVIEW_CREATE_SUCCESS;
 
 @RestController
@@ -17,10 +20,17 @@ import static com.SMWU.CarryUsServer.domain.reservation.exception.ReviewSuccessT
 @RequiredArgsConstructor
 public class ReservationController {
     private final ReservationReviewService reservationReviewService;
+    private final MemberService memberService;
 
     @PostMapping("/{reservationId}/review")
     public ResponseEntity<SuccessResponse<ReviewIdResponseDTO>> createReview(@PathVariable("reservationId") final Long reservationId, @RequestBody final ReviewCreateRequestDTO requestDTO, @AuthMember final Member member) {
         final ReviewIdResponseDTO responseDTO = reservationReviewService.createReview(reservationId, requestDTO, member);
         return ResponseEntity.ok(SuccessResponse.of(REVIEW_CREATE_SUCCESS, responseDTO));
+    }
+
+    @GetMapping("/my/info")
+    public ResponseEntity<SuccessResponse<MemberReservationDefaultInfoResponseDTO>> getMemberReservationDefaultInfo(@AuthMember final Member member) {
+        final MemberReservationDefaultInfoResponseDTO responseDTO = memberService.getMemberReservationDefaultInfo(member);
+        return ResponseEntity.ok(SuccessResponse.of(RESERVATION_MEMBER_DEFAULT_INFO_GET_SUCCESS, responseDTO));
     }
 }

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/controller/response/MemberReservationDefaultInfoResponseDTO.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/controller/response/MemberReservationDefaultInfoResponseDTO.java
@@ -1,4 +1,4 @@
-package com.SMWU.CarryUsServer.domain.member.controller.response;
+package com.SMWU.CarryUsServer.domain.reservation.controller.response;
 
 import com.SMWU.CarryUsServer.domain.member.entity.Member;
 

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/exception/ReservationSuccessType.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/exception/ReservationSuccessType.java
@@ -1,0 +1,23 @@
+package com.SMWU.CarryUsServer.domain.reservation.exception;
+
+import com.SMWU.CarryUsServer.global.exception.SuccessType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum ReservationSuccessType implements SuccessType {
+    RESERVATION_MEMBER_DEFAULT_INFO_GET_SUCCESS(HttpStatus.OK, "회원의 기본 예약 정보 조회에 성공하였습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+
+    @Override
+    public HttpStatus status() {
+        return this.status;
+    }
+
+    @Override
+    public String message() {
+        return this.message;
+    }
+}


### PR DESCRIPTION
## 🛄 PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🛄 반영 브랜치
<!-- feat/login -> dev와 같이 반영 브랜치를 표시합니다 -->
- feat/#37 -> dev
- closed #37

## 🛄 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 예약 뷰에서 사용자의 이름과 전화번호를 조회하여 가져오는 API를 구현했습니다

## 🛄 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
<img width="855" alt="image" src="https://github.com/CARRY-US/CarryUs-Server/assets/81363864/8d1b06ea-b3ad-4c0a-b77b-e4dff9db540d">


## 🛄 MEMO
<!-- 메모를 기록합니다 -->
