### PR TITLE
[FEAT] 예약 취소 요청 구현

### DIFF
--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/controller/ReservationController.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/controller/ReservationController.java
@@ -2,9 +2,12 @@ package com.SMWU.CarryUsServer.domain.reservation.controller;
 
 import com.SMWU.CarryUsServer.domain.member.entity.Member;
 import com.SMWU.CarryUsServer.domain.member.service.MemberService;
+import com.SMWU.CarryUsServer.domain.reservation.controller.request.ReservationCancelRequestDTO;
 import com.SMWU.CarryUsServer.domain.reservation.controller.request.ReviewCreateRequestDTO;
 import com.SMWU.CarryUsServer.domain.reservation.controller.response.MemberReservationDefaultInfoResponseDTO;
+import com.SMWU.CarryUsServer.domain.reservation.controller.response.ReservationIdResponseDTO;
 import com.SMWU.CarryUsServer.domain.reservation.controller.response.ReviewIdResponseDTO;
+import com.SMWU.CarryUsServer.domain.reservation.service.ReservationCancelService;
 import com.SMWU.CarryUsServer.domain.reservation.service.ReservationReviewService;
 import com.SMWU.CarryUsServer.global.response.SuccessResponse;
 import com.SMWU.CarryUsServer.global.security.AuthMember;
@@ -12,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import static com.SMWU.CarryUsServer.domain.reservation.exception.ReservationSuccessType.RESERVATION_CANCEL_SUCCESS;
 import static com.SMWU.CarryUsServer.domain.reservation.exception.ReservationSuccessType.RESERVATION_MEMBER_DEFAULT_INFO_GET_SUCCESS;
 import static com.SMWU.CarryUsServer.domain.reservation.exception.ReviewSuccessType.REVIEW_CREATE_SUCCESS;
 
@@ -21,6 +25,7 @@ import static com.SMWU.CarryUsServer.domain.reservation.exception.ReviewSuccessT
 public class ReservationController {
     private final ReservationReviewService reservationReviewService;
     private final MemberService memberService;
+    private final ReservationCancelService reservationCancelService;
 
     @PostMapping("/{reservationId}/review")
     public ResponseEntity<SuccessResponse<ReviewIdResponseDTO>> createReview(@PathVariable("reservationId") final Long reservationId, @RequestBody final ReviewCreateRequestDTO requestDTO, @AuthMember final Member member) {
@@ -32,5 +37,11 @@ public class ReservationController {
     public ResponseEntity<SuccessResponse<MemberReservationDefaultInfoResponseDTO>> getMemberReservationDefaultInfo(@AuthMember final Member member) {
         final MemberReservationDefaultInfoResponseDTO responseDTO = memberService.getMemberReservationDefaultInfo(member);
         return ResponseEntity.ok(SuccessResponse.of(RESERVATION_MEMBER_DEFAULT_INFO_GET_SUCCESS, responseDTO));
+    }
+
+    @PostMapping("")
+    public ResponseEntity<SuccessResponse<ReservationIdResponseDTO>> cancelReservation(@RequestBody final ReservationCancelRequestDTO request) {
+        final ReservationIdResponseDTO responseDTO = reservationCancelService.cancelReservation(request);
+        return ResponseEntity.ok(SuccessResponse.of(RESERVATION_CANCEL_SUCCESS, responseDTO));
     }
 }

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/controller/request/ReservationCancelRequestDTO.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/controller/request/ReservationCancelRequestDTO.java
@@ -1,0 +1,4 @@
+package com.SMWU.CarryUsServer.domain.reservation.controller.request;
+
+public record ReservationCancelRequestDTO(long reservationId, String cancelReason) {
+}

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/controller/response/ReservationIdResponseDTO.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/controller/response/ReservationIdResponseDTO.java
@@ -1,0 +1,7 @@
+package com.SMWU.CarryUsServer.domain.reservation.controller.response;
+
+public record ReservationIdResponseDTO(long reservationId) {
+    public static ReservationIdResponseDTO of(long reservationId) {
+        return new ReservationIdResponseDTO(reservationId);
+    }
+}

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/entity/Reservation.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/entity/Reservation.java
@@ -46,4 +46,8 @@ public class Reservation extends AuditingTimeEntity {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd HH:mm 예약");
         return reservationStartTime.format(formatter);
     }
+
+    public void cancelReservation(){
+        this.reservationType = ReservationType.CANCELED;
+    }
 }

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/entity/ReservationCancelReason.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/entity/ReservationCancelReason.java
@@ -2,6 +2,7 @@ package com.SMWU.CarryUsServer.domain.reservation.entity;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -19,4 +20,10 @@ public class ReservationCancelReason {
     private Reservation reservation;
 
     private String cancelReason;
+
+    @Builder
+    public ReservationCancelReason(Reservation reservation, String cancelReason) {
+        this.reservation = reservation;
+        this.cancelReason = cancelReason;
+    }
 }

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/entity/ReservationCancelReason.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/entity/ReservationCancelReason.java
@@ -1,0 +1,22 @@
+package com.SMWU.CarryUsServer.domain.reservation.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "RESERVATIONS_CANCEL_REASONS")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class ReservationCancelReason {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long reservationCancelReasonId;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reservation_id")
+    private Reservation reservation;
+
+    private String cancelReason;
+}

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/exception/ReservationSuccessType.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/exception/ReservationSuccessType.java
@@ -6,7 +6,8 @@ import org.springframework.http.HttpStatus;
 
 @RequiredArgsConstructor
 public enum ReservationSuccessType implements SuccessType {
-    RESERVATION_MEMBER_DEFAULT_INFO_GET_SUCCESS(HttpStatus.OK, "회원의 기본 예약 정보 조회에 성공하였습니다.");
+    RESERVATION_MEMBER_DEFAULT_INFO_GET_SUCCESS(HttpStatus.OK, "회원의 기본 예약 정보 조회에 성공하였습니다."),
+    RESERVATION_CANCEL_SUCCESS(HttpStatus.OK, "예약 취소에 성공하였습니다."),;
 
     private final HttpStatus status;
     private final String message;

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/repository/ReservationCancelReasonRepository.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/repository/ReservationCancelReasonRepository.java
@@ -1,0 +1,7 @@
+package com.SMWU.CarryUsServer.domain.reservation.repository;
+
+import com.SMWU.CarryUsServer.domain.reservation.entity.ReservationCancelReason;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReservationCancelReasonRepository extends JpaRepository<ReservationCancelReason, Long>{
+}

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/service/ReservationCancelService.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/service/ReservationCancelService.java
@@ -9,15 +9,18 @@ import com.SMWU.CarryUsServer.domain.reservation.repository.ReservationCancelRea
 import com.SMWU.CarryUsServer.domain.reservation.repository.ReservationRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import static com.SMWU.CarryUsServer.domain.reservation.exception.ReservationExceptionType.NOT_FOUND_RESERVATION;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class ReservationCancelService {
     private final ReservationCancelReasonRepository reservationCancelReasonRepository;
     private final ReservationRepository reservationRepository;
 
+    @Transactional
     public ReservationIdResponseDTO cancelReservation(final ReservationCancelRequestDTO request) {
         final Reservation reservation = reservationRepository.findById(request.reservationId()).orElseThrow(() -> new ReservationException(NOT_FOUND_RESERVATION));
         reservation.cancelReservation();

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/service/ReservationCancelService.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/service/ReservationCancelService.java
@@ -1,0 +1,31 @@
+package com.SMWU.CarryUsServer.domain.reservation.service;
+
+import com.SMWU.CarryUsServer.domain.reservation.controller.request.ReservationCancelRequestDTO;
+import com.SMWU.CarryUsServer.domain.reservation.controller.response.ReservationIdResponseDTO;
+import com.SMWU.CarryUsServer.domain.reservation.entity.Reservation;
+import com.SMWU.CarryUsServer.domain.reservation.entity.ReservationCancelReason;
+import com.SMWU.CarryUsServer.domain.reservation.exception.ReservationException;
+import com.SMWU.CarryUsServer.domain.reservation.repository.ReservationCancelReasonRepository;
+import com.SMWU.CarryUsServer.domain.reservation.repository.ReservationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import static com.SMWU.CarryUsServer.domain.reservation.exception.ReservationExceptionType.NOT_FOUND_RESERVATION;
+
+@Service
+@RequiredArgsConstructor
+public class ReservationCancelService {
+    private final ReservationCancelReasonRepository reservationCancelReasonRepository;
+    private final ReservationRepository reservationRepository;
+
+    public ReservationIdResponseDTO cancelReservation(final ReservationCancelRequestDTO request) {
+        final Reservation reservation = reservationRepository.findById(request.reservationId()).orElseThrow(() -> new ReservationException(NOT_FOUND_RESERVATION));
+        reservation.cancelReservation();
+        final ReservationCancelReason reservationCancelReason = ReservationCancelReason.builder()
+                .reservation(reservation)
+                .cancelReason(request.cancelReason())
+                .build();
+        reservationCancelReasonRepository.save(reservationCancelReason);
+        return ReservationIdResponseDTO.of(reservation.getReservationId());
+    }
+}

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/global/security/config/SecurityConfig.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/global/security/config/SecurityConfig.java
@@ -24,7 +24,7 @@ public class SecurityConfig {
 
     public static final String[] AUTH_WHITELIST = {
             "/", "/error",
-            "/favicon.ico",
+            "/favicon.ico.",
             "/actuator/health", "/check/profile"
     };
 


### PR DESCRIPTION
## 🛄 PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🛄 반영 브랜치
<!-- feat/login -> dev와 같이 반영 브랜치를 표시합니다 -->
- feat/#41 -> dev
- closed #41

## 🛄 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 예약 취소 내용을 저장하는 엔티티(테이블)을 추가했습니다
- 예약을 취소하는 기능을 구현했습니다

## 🛄 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
<img width="858" alt="image" src="https://github.com/CARRY-US/CarryUs-Server/assets/81363864/5dcd56cf-a667-4a27-87fc-4d30e771fbde">


## 🛄 MEMO
<!-- 메모를 기록합니다 -->
