### PR TITLE
[FEAT] 예약 상태 별 리스트 조회 구현

### DIFF
--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/controller/ReservationController.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/controller/ReservationController.java
@@ -4,9 +4,7 @@ import com.SMWU.CarryUsServer.domain.member.entity.Member;
 import com.SMWU.CarryUsServer.domain.member.service.MemberService;
 import com.SMWU.CarryUsServer.domain.reservation.controller.request.ReservationCancelRequestDTO;
 import com.SMWU.CarryUsServer.domain.reservation.controller.request.ReviewCreateRequestDTO;
-import com.SMWU.CarryUsServer.domain.reservation.controller.response.MemberReservationDefaultInfoResponseDTO;
-import com.SMWU.CarryUsServer.domain.reservation.controller.response.ReservationIdResponseDTO;
-import com.SMWU.CarryUsServer.domain.reservation.controller.response.ReviewIdResponseDTO;
+import com.SMWU.CarryUsServer.domain.reservation.controller.response.*;
 import com.SMWU.CarryUsServer.domain.reservation.service.ReservationCancelService;
 import com.SMWU.CarryUsServer.domain.reservation.service.ReservationReviewService;
 import com.SMWU.CarryUsServer.global.response.SuccessResponse;
@@ -15,8 +13,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 import static com.SMWU.CarryUsServer.domain.reservation.exception.ReservationSuccessType.RESERVATION_CANCEL_SUCCESS;
 import static com.SMWU.CarryUsServer.domain.reservation.exception.ReservationSuccessType.RESERVATION_MEMBER_DEFAULT_INFO_GET_SUCCESS;
+import static com.SMWU.CarryUsServer.domain.reservation.exception.ReviewSuccessType.REVIEW_BY_STATUS_GET_SUCCESS;
 import static com.SMWU.CarryUsServer.domain.reservation.exception.ReviewSuccessType.REVIEW_CREATE_SUCCESS;
 
 @RestController
@@ -43,5 +44,11 @@ public class ReservationController {
     public ResponseEntity<SuccessResponse<ReservationIdResponseDTO>> cancelReservation(@RequestBody final ReservationCancelRequestDTO request) {
         final ReservationIdResponseDTO responseDTO = reservationCancelService.cancelReservation(request);
         return ResponseEntity.ok(SuccessResponse.of(RESERVATION_CANCEL_SUCCESS, responseDTO));
+    }
+
+    @GetMapping("")
+    public ResponseEntity<SuccessResponse<List<ReservationFilteredByStatusResponseDTO>>> getMemberReviewListByReviewStatus(@RequestParam final String status, @AuthMember final Member member){
+        final List<ReservationFilteredByStatusResponseDTO> responseDTO = reservationReviewService.getMemberReviewListByReviewStatus(status, member);
+        return ResponseEntity.ok(SuccessResponse.of(REVIEW_BY_STATUS_GET_SUCCESS, responseDTO));
     }
 }

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/controller/response/ReservationFilteredByStatusResponseDTO.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/controller/response/ReservationFilteredByStatusResponseDTO.java
@@ -1,0 +1,10 @@
+package com.SMWU.CarryUsServer.domain.reservation.controller.response;
+
+import com.SMWU.CarryUsServer.domain.reservation.entity.Reservation;
+import com.SMWU.CarryUsServer.domain.store.entity.Store;
+
+public record ReservationFilteredByStatusResponseDTO(long reservationId, String storeName, String storeImgUrl, String storeLocation, String reservationInfo) {
+    public static ReservationFilteredByStatusResponseDTO of(final Store store, final Reservation reservation) {
+        return new ReservationFilteredByStatusResponseDTO(reservation.getReservationId(), store.getStoreName(), store.getStoreImgUrl(), store.getStoreLocation(), reservation.getReservationInfo());
+    }
+}

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/controller/response/ReservationStoreInfoResponseDTO.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/controller/response/ReservationStoreInfoResponseDTO.java
@@ -2,8 +2,8 @@ package com.SMWU.CarryUsServer.domain.reservation.controller.response;
 
 import com.SMWU.CarryUsServer.domain.store.entity.Store;
 
-public record ReservationStoreInfoResponseDTO(long storeId, String storeName, String storeLocation, String reservationInfo) {
+public record ReservationStoreInfoResponseDTO(long storeId, String storeName, String storeImgUrl, String storeLocation, String reservationInfo) {
     public static ReservationStoreInfoResponseDTO of(final Store store, final String reservationInfo) {
-        return new ReservationStoreInfoResponseDTO(store.getStoreId(), store.getStoreName(), store.getStoreLocation(), reservationInfo);
+        return new ReservationStoreInfoResponseDTO(store.getStoreId(), store.getStoreName(), store.getStoreImgUrl(), store.getStoreLocation(), reservationInfo);
     }
 }

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/exception/ReviewSuccessType.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/exception/ReviewSuccessType.java
@@ -9,7 +9,8 @@ public enum ReviewSuccessType implements SuccessType {
     REVIEW_GET_SUCCESS(HttpStatus.OK, "리뷰 상세 조회에 성공하였습니다."),
     REVIEW_STORE_INFO_GET_SUCCESS(HttpStatus.OK, "리뷰를 남긴 가게에 대한 정보 조회에 성공하였습니다."),
     REVIEW_UPDATE_SUCCESS(HttpStatus.OK, "리뷰 수정에 성공하였습니다."),
-    REVIEW_CREATE_SUCCESS(HttpStatus.CREATED, "리뷰 작성에 성공하였습니다.");
+    REVIEW_CREATE_SUCCESS(HttpStatus.CREATED, "리뷰 작성에 성공하였습니다."),
+    REVIEW_BY_STATUS_GET_SUCCESS(HttpStatus.OK, "리뷰 상태별 조회에 성공하였습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/repository/ReservationRepository.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/repository/ReservationRepository.java
@@ -2,10 +2,12 @@ package com.SMWU.CarryUsServer.domain.reservation.repository;
 
 import com.SMWU.CarryUsServer.domain.member.entity.Member;
 import com.SMWU.CarryUsServer.domain.reservation.entity.Reservation;
+import com.SMWU.CarryUsServer.domain.reservation.entity.enums.ReservationType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ReservationRepository extends JpaRepository<Reservation, Long> {
@@ -13,4 +15,6 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
 
     @Query("SELECT r FROM Reservation r JOIN ReservationReview rr on r = rr.reservation JOIN FETCH r.store WHERE rr.reservationReviewId = :reviewId AND r.client = :client")
     Optional<Reservation> findReservationWithReservationStore(@Param("reviewId") Long reviewId, @Param("client") Member client);
+
+    List<Reservation> findAllByReservationTypeAndClientOrderByCreatedAtDesc(final ReservationType reservationType, final Member client);
 }

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/service/ReservationReviewService.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/service/ReservationReviewService.java
@@ -70,6 +70,20 @@ public class ReservationReviewService {
         return ReservationStoreInfoResponseDTO.of(reservation.getStore(), reservation.getReservationInfo());
     }
 
+    public List<ReservationFilteredByStatusResponseDTO> getMemberReviewListByReviewStatus(final String status, final Member member){
+        final ReservationType reservationType = ReservationType.valueOf(status);
+        final List<Reservation> reservationList = reservationRepository.findAllByReservationTypeAndClientOrderByCreatedAtDesc(reservationType, member);
+        return getReservationStoreInfoList(reservationList);
+    }
+
+    private List<ReservationFilteredByStatusResponseDTO> getReservationStoreInfoList(final List<Reservation> reservationList){
+        List<ReservationFilteredByStatusResponseDTO> responseDTO = new ArrayList<>();
+        for (Reservation reservation : reservationList) {
+            responseDTO.add(ReservationFilteredByStatusResponseDTO.of(reservation.getStore(), reservation));
+        }
+        return responseDTO;
+    }
+
     @Transactional
     public ReviewIdResponseDTO createReview(final Long reservationId, final ReviewCreateRequestDTO requestDTO, final Member member) {
         final Reservation reservation = reservationRepository.findByReservationIdAndClient(reservationId, member)


### PR DESCRIPTION
## 🛄 PR 타입
- [x] 기능 추가
- [x] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🛄 반영 브랜치
<!-- feat/login -> dev와 같이 반영 브랜치를 표시합니다 -->
- feat/#43 -> dev
- closed #43

## 🛄 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- ReservationStoreInfoResponseDTO에 가게 이미지 경로가 누락되어 추가했습니다
- 예약 상태 별 리스트를 조회하는 API를 개발했습니다

## 🛄 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
<img width="849" alt="image" src="https://github.com/CARRY-US/CarryUs-Server/assets/81363864/f5edf8b6-4842-4591-bf6a-0cf47ec3e15e">


## 🛄 MEMO
<!-- 메모를 기록합니다 -->
