### PR TITLE
[FEAT] 가게 요청서 생성 

### DIFF
--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/controller/request/ReservationCreateRequestDTO.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/controller/request/ReservationCreateRequestDTO.java
@@ -1,0 +1,27 @@
+package com.SMWU.CarryUsServer.domain.reservation.controller.request;
+
+import com.SMWU.CarryUsServer.domain.store.entity.enums.BaggageType;
+
+import java.time.LocalDateTime;
+import java.util.concurrent.ConcurrentHashMap;
+
+public record ReservationCreateRequestDTO(
+        int extraSmallCount,
+        int smallCount,
+        int largeCount,
+        int extraLargeCount,
+        LocalDateTime reservationStartTime,
+        LocalDateTime reservationEndTime,
+        String memberName,
+        String memberPhoneNumber,
+        String memberRequestContent
+) {
+    public static ConcurrentHashMap<BaggageType, Integer> createBaggageCountMap(final ReservationCreateRequestDTO request){
+        ConcurrentHashMap<BaggageType, Integer> baggageCount = new ConcurrentHashMap<>();
+        baggageCount.put(BaggageType.EXTRASMALL, request.extraSmallCount());
+        baggageCount.put(BaggageType.SMALL, request.smallCount());
+        baggageCount.put(BaggageType.LARGE, request.largeCount());
+        baggageCount.put(BaggageType.EXTRALARGE, request.extraLargeCount());
+        return baggageCount;
+    }
+}

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/entity/Reservation.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/entity/Reservation.java
@@ -6,6 +6,7 @@ import com.SMWU.CarryUsServer.domain.store.entity.Store;
 import com.SMWU.CarryUsServer.global.entity.AuditingTimeEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -49,5 +50,21 @@ public class Reservation extends AuditingTimeEntity {
 
     public void cancelReservation(){
         this.reservationType = ReservationType.CANCELED;
+    }
+
+    public void updatePayment(int payment){
+        this.payment = payment;
+    }
+
+    @Builder
+    public Reservation(Member client, Store store, String clientReservationPhoneNumber, ReservationType reservationType, String clientRequestContent, int payment, LocalDateTime reservationStartTime, LocalDateTime reservationEndTime) {
+        this.client = client;
+        this.store = store;
+        this.clientReservationPhoneNumber = clientReservationPhoneNumber;
+        this.reservationType = reservationType;
+        this.clientRequestContent = clientRequestContent;
+        this.payment = payment;
+        this.reservationStartTime = reservationStartTime;
+        this.reservationEndTime = reservationEndTime;
     }
 }

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/entity/ReservationBaggage.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/entity/ReservationBaggage.java
@@ -3,6 +3,7 @@ package com.SMWU.CarryUsServer.domain.reservation.entity;
 import com.SMWU.CarryUsServer.domain.store.entity.StoreBaggage;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -27,5 +28,12 @@ public class ReservationBaggage {
 
     public String getReservationBaggageInfo(){
         return storeBaggage.getBaggageType().getMessage()+" "+reservationBaggageCount+"개";
+    }
+
+    @Builder
+    public ReservationBaggage(Reservation reservation, StoreBaggage storeBaggage, int reservationBaggageCount) {
+        this.reservation = reservation;
+        this.storeBaggage = storeBaggage;
+        this.reservationBaggageCount = reservationBaggageCount;
     }
 }

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/exception/ReservationExceptionType.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/exception/ReservationExceptionType.java
@@ -7,6 +7,7 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum ReservationExceptionType implements ExceptionType {
     NOT_COMPLETED_RESERVATION(HttpStatus.BAD_REQUEST, "예약이 완료되지 않았습니다."),
+    NOT_VALIDATE_RESERVATION_BAGGAGE(HttpStatus.BAD_REQUEST, "해당 시간대에 예약 가능한 캐리어의 개수를 초과했습니다."),
     NOT_FOUND_RESERVATION(HttpStatus.NOT_FOUND, "예약을 찾을 수 없습니다.");
 
     private final HttpStatus status;

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/exception/ReservationSuccessType.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/exception/ReservationSuccessType.java
@@ -8,7 +8,8 @@ import org.springframework.http.HttpStatus;
 public enum ReservationSuccessType implements SuccessType {
     RESERVATION_MEMBER_DEFAULT_INFO_GET_SUCCESS(HttpStatus.OK, "회원의 기본 예약 정보 조회에 성공하였습니다."),
     RESERVATION_CANCEL_SUCCESS(HttpStatus.OK, "예약 취소에 성공하였습니다."),
-    RESERVATION_DETAIL_GET_SUCCESS(HttpStatus.OK, "예약 상세 정보 조회에 성공하였습니다.");
+    RESERVATION_DETAIL_GET_SUCCESS(HttpStatus.OK, "예약 상세 정보 조회에 성공하였습니다."),
+    RESERVATION_CREATE_SUCCESS(HttpStatus.CREATED, "예약 생성에 성공했습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/repository/ReservationBaggageRepository.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/repository/ReservationBaggageRepository.java
@@ -2,10 +2,16 @@ package com.SMWU.CarryUsServer.domain.reservation.repository;
 
 import com.SMWU.CarryUsServer.domain.reservation.entity.Reservation;
 import com.SMWU.CarryUsServer.domain.reservation.entity.ReservationBaggage;
+import com.SMWU.CarryUsServer.domain.store.entity.StoreBaggage;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface ReservationBaggageRepository extends JpaRepository<ReservationBaggage, Long> {
     List<ReservationBaggage> findAllByReservation(Reservation reservation);
+
+    @Query("select rb from ReservationBaggage rb where rb.storeBaggage = :storeBaggage and :time between rb.reservation.reservationStartTime and rb.reservation.reservationEndTime")
+    List<ReservationBaggage> findAllByStoreBaggageWithTime(StoreBaggage storeBaggage, LocalDateTime time);
 }

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/service/ReservationCreateService.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/service/ReservationCreateService.java
@@ -1,0 +1,98 @@
+package com.SMWU.CarryUsServer.domain.reservation.service;
+
+import com.SMWU.CarryUsServer.domain.member.entity.Member;
+import com.SMWU.CarryUsServer.domain.reservation.controller.request.ReservationCreateRequestDTO;
+import com.SMWU.CarryUsServer.domain.reservation.controller.response.ReservationIdResponseDTO;
+import com.SMWU.CarryUsServer.domain.reservation.entity.Reservation;
+import com.SMWU.CarryUsServer.domain.reservation.entity.ReservationBaggage;
+import com.SMWU.CarryUsServer.domain.reservation.entity.enums.ReservationType;
+import com.SMWU.CarryUsServer.domain.reservation.exception.ReservationException;
+import com.SMWU.CarryUsServer.domain.reservation.repository.ReservationBaggageRepository;
+import com.SMWU.CarryUsServer.domain.reservation.repository.ReservationRepository;
+import com.SMWU.CarryUsServer.domain.store.entity.Store;
+import com.SMWU.CarryUsServer.domain.store.entity.StoreBaggage;
+import com.SMWU.CarryUsServer.domain.store.entity.enums.BaggageType;
+import com.SMWU.CarryUsServer.domain.store.exception.StoreException;
+import com.SMWU.CarryUsServer.domain.store.repository.StoreBaggageRepository;
+import com.SMWU.CarryUsServer.domain.store.repository.StoreRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static com.SMWU.CarryUsServer.domain.reservation.exception.ReservationExceptionType.NOT_VALIDATE_RESERVATION_BAGGAGE;
+import static com.SMWU.CarryUsServer.domain.store.exception.StoreExceptionType.NOT_FOUND_STORE_BAGGAGE;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Slf4j
+public class ReservationCreateService {
+    private static final ReservationType RESERVATION_INIT_STATUS = ReservationType.WAITING;
+    private final ReservationRepository reservationRepository;
+    private final ReservationBaggageRepository reservationBaggageRepository;
+    private final StoreBaggageRepository storeBaggageRepository;
+    private final StoreRepository storeRepository;
+
+    @Transactional
+    public ReservationIdResponseDTO createReservation(final ReservationCreateRequestDTO request, final Long storeId, final Member member) {
+        Store store = storeRepository.findById(storeId).orElseThrow(() -> new StoreException(NOT_FOUND_STORE_BAGGAGE));
+        ConcurrentHashMap<BaggageType, Integer> baggageCountMap = ReservationCreateRequestDTO.createBaggageCountMap(request);
+        Reservation reservation = createReservationEntity(request, store, member);
+        reservationRepository.save(reservation);
+        validateAndCreateReservationBaggage(baggageCountMap, store, request.reservationStartTime(), request.reservationEndTime(), reservation);
+        return ReservationIdResponseDTO.of(reservation.getReservationId());
+    }
+
+    private Reservation createReservationEntity(final ReservationCreateRequestDTO request, final Store store, final Member member) {
+        return Reservation.builder()
+                .client(member)
+                .store(store)
+                .clientReservationPhoneNumber(request.memberPhoneNumber())
+                .reservationType(RESERVATION_INIT_STATUS)
+                .clientRequestContent(request.memberRequestContent())
+                .reservationStartTime(request.reservationStartTime())
+                .reservationEndTime(request.reservationEndTime())
+                .build();
+    }
+
+    private void validateAndCreateReservationBaggage(final ConcurrentHashMap<BaggageType, Integer> baggageCount, final Store store, final LocalDateTime reservationStartTime, final LocalDateTime reservationEndTime, final Reservation reservation) {
+        int payment = 0;
+        int count = 0;
+        StoreBaggage storeBaggage = null;
+        System.out.println(reservationStartTime);
+
+        for (BaggageType baggageType : BaggageType.values()) {
+            for (LocalDateTime time = reservationStartTime; time.isBefore(reservationEndTime); time = time.plusHours(1)) {
+                count = baggageCount.get(baggageType);
+                storeBaggage = storeBaggageRepository.findByStoreAndBaggageType(store, baggageType)
+                        .orElseThrow(() -> new StoreException(NOT_FOUND_STORE_BAGGAGE));
+                int reservedCount = reservationBaggageRepository.findAllByStoreBaggageWithTime(storeBaggage, time)
+                        .stream()
+                        .mapToInt(ReservationBaggage::getReservationBaggageCount)
+                        .sum();
+                if (count + reservedCount > storeBaggage.getBaggageCount()) {
+                    throw new ReservationException(NOT_VALIDATE_RESERVATION_BAGGAGE);
+                }
+            }
+            createReservationBaggage(count, storeBaggage, reservation);
+            payment += Objects.requireNonNull(storeBaggage).getBaggagePrice() * count;
+        }
+        reservation.updatePayment(payment);
+    }
+
+    private void createReservationBaggage(final int count, final StoreBaggage storeBaggage, final Reservation reservation) {
+        if (count > 0) {
+            ReservationBaggage reservationBaggage = ReservationBaggage.builder()
+                    .reservation(reservation)
+                    .storeBaggage(storeBaggage)
+                    .reservationBaggageCount(count)
+                    .build();
+            reservationBaggageRepository.save(reservationBaggage);
+        }
+    }
+}

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/service/ReservationCreateService.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/service/ReservationCreateService.java
@@ -64,7 +64,6 @@ public class ReservationCreateService {
         int payment = 0;
         int count = 0;
         StoreBaggage storeBaggage = null;
-        System.out.println(reservationStartTime);
 
         for (BaggageType baggageType : BaggageType.values()) {
             for (LocalDateTime time = reservationStartTime; time.isBefore(reservationEndTime); time = time.plusHours(1)) {

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/service/ReservationService.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/service/ReservationService.java
@@ -8,6 +8,8 @@ import com.SMWU.CarryUsServer.domain.reservation.exception.ReservationException;
 import com.SMWU.CarryUsServer.domain.reservation.repository.ReservationBaggageRepository;
 import com.SMWU.CarryUsServer.domain.reservation.repository.ReservationRepository;
 import com.SMWU.CarryUsServer.domain.store.entity.Store;
+import com.SMWU.CarryUsServer.domain.store.repository.StoreBaggageRepository;
+import com.SMWU.CarryUsServer.domain.store.repository.StoreRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -39,7 +41,7 @@ public class ReservationService {
             reservationBaggageInfo.append(rb.getReservationBaggageInfo()).append(", ");
         }
         if (!reservationBaggageInfo.isEmpty()) {
-            reservationBaggageInfo.setLength(reservationBaggageInfo.length() - 2); // 마지막 쉼표와 공백 제거
+            reservationBaggageInfo.setLength(reservationBaggageInfo.length() - 2);
         }
         return reservationBaggageInfo.toString();
     }

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/store/controller/StoreController.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/store/controller/StoreController.java
@@ -1,17 +1,23 @@
 package com.SMWU.CarryUsServer.domain.store.controller;
 
+import com.SMWU.CarryUsServer.domain.member.entity.Member;
+import com.SMWU.CarryUsServer.domain.reservation.controller.request.ReservationCreateRequestDTO;
+import com.SMWU.CarryUsServer.domain.reservation.controller.response.ReservationIdResponseDTO;
 import com.SMWU.CarryUsServer.domain.reservation.controller.response.StoreReviewResponseListDTO;
+import com.SMWU.CarryUsServer.domain.reservation.service.ReservationCreateService;
 import com.SMWU.CarryUsServer.domain.reservation.service.ReservationReviewService;
 import com.SMWU.CarryUsServer.domain.store.controller.response.StoreDetailResponseDTO;
 import com.SMWU.CarryUsServer.domain.store.service.StoreService;
 import com.SMWU.CarryUsServer.global.response.SuccessResponse;
+import com.SMWU.CarryUsServer.global.security.AuthMember;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
+import java.net.URI;
+
+import static com.SMWU.CarryUsServer.domain.reservation.exception.ReservationSuccessType.RESERVATION_CREATE_SUCCESS;
 import static com.SMWU.CarryUsServer.domain.store.exception.StoreSuccessType.GET_STORE_DETAIL;
 import static com.SMWU.CarryUsServer.domain.store.exception.StoreSuccessType.GET_STORE_REVIEW_LIST;
 
@@ -21,16 +27,24 @@ import static com.SMWU.CarryUsServer.domain.store.exception.StoreSuccessType.GET
 public class StoreController {
     private final ReservationReviewService reservationReviewService;
     private final StoreService storeService;
+    private final ReservationCreateService reservationCreateService;
 
     @GetMapping("/{storeId}/reviews")
     public ResponseEntity<SuccessResponse<StoreReviewResponseListDTO>> getStoreReviewList(@PathVariable final long storeId) {
-        StoreReviewResponseListDTO responseDTO = reservationReviewService.getStoreReviewList(storeId);
+        final StoreReviewResponseListDTO responseDTO = reservationReviewService.getStoreReviewList(storeId);
         return ResponseEntity.ok().body(SuccessResponse.of(GET_STORE_REVIEW_LIST, responseDTO));
     }
 
     @GetMapping("/{storeId}/detail")
     public ResponseEntity<SuccessResponse<StoreDetailResponseDTO>> getStoreDetail(@PathVariable final long storeId) {
-        StoreDetailResponseDTO responseDTO = storeService.getStoreDetail(storeId);
+        final StoreDetailResponseDTO responseDTO = storeService.getStoreDetail(storeId);
         return ResponseEntity.ok().body(SuccessResponse.of(GET_STORE_DETAIL, responseDTO));
+    }
+
+    @PostMapping("/{storeId}/reservation")
+    public ResponseEntity<SuccessResponse<ReservationIdResponseDTO>> createReservation(@PathVariable final long storeId, @RequestBody final ReservationCreateRequestDTO request, @AuthMember final Member member) {
+        final ReservationIdResponseDTO response = reservationCreateService.createReservation(request, storeId, member);
+        URI resourceUri = URI.create("/reservation/"+response.reservationId());
+        return ResponseEntity.created(resourceUri).body(SuccessResponse.of(RESERVATION_CREATE_SUCCESS, response));
     }
 }

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/store/exception/StoreException.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/store/exception/StoreException.java
@@ -1,0 +1,10 @@
+package com.SMWU.CarryUsServer.domain.store.exception;
+
+import com.SMWU.CarryUsServer.global.exception.ClientException;
+import com.SMWU.CarryUsServer.global.exception.ExceptionType;
+
+public class StoreException extends ClientException {
+    public StoreException(ExceptionType exceptionType) {
+        super(exceptionType);
+    }
+}

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/store/exception/StoreExceptionType.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/store/exception/StoreExceptionType.java
@@ -1,0 +1,24 @@
+package com.SMWU.CarryUsServer.domain.store.exception;
+
+import com.SMWU.CarryUsServer.global.exception.ExceptionType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum StoreExceptionType implements ExceptionType {
+    NOT_FOUND_STORE(HttpStatus.NOT_FOUND, "가게를 찾을 수 없습니다"),
+    NOT_FOUND_STORE_BAGGAGE(HttpStatus.NOT_FOUND, "가게에 해당하는 캐리어를 찾을 수 없습니다");
+
+    private final HttpStatus status;
+    private final String message;
+
+    @Override
+    public HttpStatus status() {
+        return this.status;
+    }
+
+    @Override
+    public String message() {
+        return this.message;
+    }
+}

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/store/repository/StoreBaggageRepository.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/store/repository/StoreBaggageRepository.java
@@ -2,10 +2,13 @@ package com.SMWU.CarryUsServer.domain.store.repository;
 
 import com.SMWU.CarryUsServer.domain.store.entity.Store;
 import com.SMWU.CarryUsServer.domain.store.entity.StoreBaggage;
+import com.SMWU.CarryUsServer.domain.store.entity.enums.BaggageType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface StoreBaggageRepository extends JpaRepository<StoreBaggage, Long> {
     List<StoreBaggage> findAllByStoreOrderByStoreBaggageIdAsc(Store store);
+    Optional<StoreBaggage> findByStoreAndBaggageType(Store store, BaggageType baggageType);
 }

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/global/exception/GlobalExceptionHandler.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/global/exception/GlobalExceptionHandler.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.servlet.NoHandlerFoundException;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 import static com.SMWU.CarryUsServer.global.exception.CommonExceptionType.*;
 
@@ -34,10 +35,10 @@ public class GlobalExceptionHandler {
                 .body(ErrorResponse.of(INTERNAL_SERVER_ERROR));
     }
 
-    @ExceptionHandler(NoHandlerFoundException.class)
-    protected ResponseEntity<ErrorResponse> handleNotFoundException(final NoHandlerFoundException ex) {
+    @ExceptionHandler(NoResourceFoundException.class)
+    protected ResponseEntity<ErrorResponse> handleNotFoundException(final NoResourceFoundException ex) {
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                .body(ErrorResponse.of(NOT_FOUND_PATH, ex.getRequestURL()));
+                .body(ErrorResponse.of(NOT_FOUND_PATH, ex.getResourcePath()));
     }
 
     @ExceptionHandler(MethodArgumentTypeMismatchException.class)


### PR DESCRIPTION
## 🛄 PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🛄 반영 브랜치
<!-- feat/login -> dev와 같이 반영 브랜치를 표시합니다 -->
- feat/#47 -> dev
- closed #47

## 🛄 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 가게 요청서 생성(예약 생성) 기능을 구현했습니다

## 🛄 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
<img width="832" alt="image" src="https://github.com/CARRY-US/CarryUs-Server/assets/81363864/bf709feb-25c0-44e6-a79c-6aeee8eba0a4">


## 🛄 MEMO
<!-- 메모를 기록합니다 -->
