### PR TITLE
[FEAT] 예약 상태 별 리스트 조회에서 리뷰 존재 유무 필드 추가

### DIFF
--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/controller/ReservationController.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/controller/ReservationController.java
@@ -54,8 +54,8 @@ public class ReservationController {
     }
 
     @GetMapping("")
-    public ResponseEntity<SuccessResponse<List<ReservationFilteredByStatusResponseDTO>>> getMemberReviewListByReviewStatus(@RequestParam final String status, @AuthMember final Member member){
-        final List<ReservationFilteredByStatusResponseDTO> responseDTO = reservationReviewService.getMemberReviewListByReviewStatus(status, member);
+    public ResponseEntity<SuccessResponse<List<ReservationFilteredByStatusResponseDTO>>> getMemberReservationByReservationStatus(@RequestParam final String status, @AuthMember final Member member){
+        final List<ReservationFilteredByStatusResponseDTO> responseDTO = reservationReviewService.getMemberReservationByReservationStatus(status, member);
         return ResponseEntity.ok(SuccessResponse.of(REVIEW_BY_STATUS_GET_SUCCESS, responseDTO));
     }
 }

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/controller/response/ReservationFilteredByStatusResponseDTO.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/controller/response/ReservationFilteredByStatusResponseDTO.java
@@ -3,8 +3,8 @@ package com.SMWU.CarryUsServer.domain.reservation.controller.response;
 import com.SMWU.CarryUsServer.domain.reservation.entity.Reservation;
 import com.SMWU.CarryUsServer.domain.store.entity.Store;
 
-public record ReservationFilteredByStatusResponseDTO(long reservationId, String storeName, String storeImgUrl, String storeLocation, String reservationInfo) {
-    public static ReservationFilteredByStatusResponseDTO of(final Store store, final Reservation reservation) {
-        return new ReservationFilteredByStatusResponseDTO(reservation.getReservationId(), store.getStoreName(), store.getStoreImgUrl(), store.getStoreLocation(), reservation.getReservationInfo());
+public record ReservationFilteredByStatusResponseDTO(long reservationId, String storeName, String storeImgUrl, String storeLocation, String reservationInfo, boolean isReviewExist) {
+    public static ReservationFilteredByStatusResponseDTO of(final Store store, final Reservation reservation, boolean isReviewExist) {
+        return new ReservationFilteredByStatusResponseDTO(reservation.getReservationId(), store.getStoreName(), store.getStoreImgUrl(), store.getStoreLocation(), reservation.getReservationInfo(), isReviewExist);
     }
 }

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/repository/ReservationReviewRepository.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/repository/ReservationReviewRepository.java
@@ -1,6 +1,7 @@
 package com.SMWU.CarryUsServer.domain.reservation.repository;
 
 import com.SMWU.CarryUsServer.domain.member.entity.Member;
+import com.SMWU.CarryUsServer.domain.reservation.entity.Reservation;
 import com.SMWU.CarryUsServer.domain.reservation.entity.ReservationReview;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -23,4 +24,6 @@ public interface ReservationReviewRepository extends JpaRepository<ReservationRe
 
     @Query("SELECT rr FROM ReservationReview rr JOIN FETCH rr.reservation r WHERE r.store.storeId =:storeId")
     List<ReservationReview> getReservationReviewByStore(@Param("storeId") Long storeId);
+
+    boolean existsByReservation(Reservation reservation);
 }

--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/service/ReservationReviewService.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/service/ReservationReviewService.java
@@ -70,7 +70,7 @@ public class ReservationReviewService {
         return ReservationStoreInfoResponseDTO.of(reservation.getStore(), reservation.getReservationInfo());
     }
 
-    public List<ReservationFilteredByStatusResponseDTO> getMemberReviewListByReviewStatus(final String status, final Member member){
+    public List<ReservationFilteredByStatusResponseDTO> getMemberReservationByReservationStatus(final String status, final Member member){
         final ReservationType reservationType = ReservationType.valueOf(status);
         final List<Reservation> reservationList = reservationRepository.findAllByReservationTypeAndClientOrderByCreatedAtDesc(reservationType, member);
         return getReservationStoreInfoList(reservationList);
@@ -78,8 +78,12 @@ public class ReservationReviewService {
 
     private List<ReservationFilteredByStatusResponseDTO> getReservationStoreInfoList(final List<Reservation> reservationList){
         List<ReservationFilteredByStatusResponseDTO> responseDTO = new ArrayList<>();
+        boolean isReviewExist = false;
         for (Reservation reservation : reservationList) {
-            responseDTO.add(ReservationFilteredByStatusResponseDTO.of(reservation.getStore(), reservation));
+            boolean reservationTypeISCompleted = reservation.getReservationType().equals(ReservationType.COMPLETED);
+            boolean reservationHasReview = reservationReviewRepository.existsByReservation(reservation);
+            isReviewExist = reservationTypeISCompleted && reservationHasReview;
+            responseDTO.add(ReservationFilteredByStatusResponseDTO.of(reservation.getStore(), reservation, isReviewExist));
         }
         return responseDTO;
     }


### PR DESCRIPTION
## 🛄 PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🛄 반영 브랜치
<!-- feat/login -> dev와 같이 반영 브랜치를 표시합니다 -->
- feat/#51 -> dev
- closed #51

## 🛄 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 예약 상태 별 리스트 조회에서 리뷰 존재 유무 필드를 추가했습니다

## 🛄 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
<img width="863" alt="Screenshot 2024-03-27 at 5 41 31 PM" src="https://github.com/CARRY-US/CarryUs-Server/assets/81363864/2df8f6ff-c5ff-418b-acc1-92c4b86564a6">


## 🛄 MEMO
<!-- 메모를 기록합니다 -->
