### PR TITLE
[FEAT] getStoreRating 소수점 첫째짜리까지 표현되도록 변경

### DIFF
--- a/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/repository/ReservationReviewRepository.java
+++ b/CarryUsServer/src/main/java/com/SMWU/CarryUsServer/domain/reservation/repository/ReservationReviewRepository.java
@@ -16,7 +16,7 @@ public interface ReservationReviewRepository extends JpaRepository<ReservationRe
 
     Optional<ReservationReview> findByReservationReviewIdAndReservationClient(Long reservationId, Member client);
 
-    @Query("SELECT AVG(rr.reviewRating) FROM ReservationReview rr JOIN rr.reservation r WHERE r.store.storeId = :storeId")
+    @Query("SELECT ROUND(AVG(rr.reviewRating),1) FROM ReservationReview rr JOIN rr.reservation r WHERE r.store.storeId = :storeId")
     Optional<Double> getStoreRating(@Param("storeId") Long storeId);
 
     @Query("SELECT COUNT(rr) FROM ReservationReview rr JOIN rr.reservation r WHERE r.store.storeId = :storeId")


### PR DESCRIPTION
## 🛄 PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🛄 반영 브랜치
<!-- feat/login -> dev와 같이 반영 브랜치를 표시합니다 -->
- feat/#53 -> dev
- closed #53 

## 🛄 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 가게 리뷰 리스트 조회 시 리뷰 평점을 소수점 첫째짜리까지 표현되도록 수정했습니다.

## 🛄 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
<img width="761" alt="image" src="https://github.com/CARRY-US/CarryUs-Server/assets/81363864/3d00cd91-e0ae-4962-9b9d-4383455cf15c">


## 🛄 MEMO
<!-- 메모를 기록합니다 -->
